### PR TITLE
Add NAS2D as a Git submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: outpostuniverse/ubuntu-18.04-circleci-gcc-sdl2
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update
+      - run:
+          name: "Build"
+          command: make -k

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nas2d-core"]
+	path = nas2d-core
+	url = https://github.com/lairworks/nas2d-core.git

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ BINDIR := .
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 EXE := $(BINDIR)/OPHD
+NAS2DLIB := $(LIBDIR)/libnas2d.a
 
 CFLAGS := -std=c++11 -g -Wall -Wno-unknown-pragmas -I$(INCDIR) $(shell sdl2-config --cflags)
 LDFLAGS := -lstdc++ -lm -L$(LIBDIR) -lnas2d \
@@ -26,9 +27,15 @@ FOLDERS := $(sort $(dir $(SRCS)))
 
 all: $(EXE)
 
-$(EXE): $(OBJS)
+$(EXE): $(NAS2DLIB) $(OBJS)
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) -o $@
+
+$(NAS2DLIB): nas2d
+
+.PHONY:nas2d
+nas2d:
+	$(MAKE) -C nas2d-core
 
 $(OBJS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp $(DEPDIR)/%.d | build-folder
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<

--- a/makefile
+++ b/makefile
@@ -1,17 +1,18 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
 SRCDIR := src
-INCDIR := nas2d-core/include
-LIBDIR := nas2d-core/lib
 BUILDDIR := build
 BINDIR := .
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 EXE := $(BINDIR)/OPHD
-NAS2DLIB := $(LIBDIR)/libnas2d.a
+NAS2DDIR := nas2d-core
+NAS2DINCLUDEDIR := $(NAS2DDIR)/include
+NAS2DLIBDIR := $(NAS2DDIR)/lib
+NAS2DLIB := $(NAS2DLIBDIR)/libnas2d.a
 
-CFLAGS := -std=c++11 -g -Wall -Wno-unknown-pragmas -I$(INCDIR) $(shell sdl2-config --cflags)
-LDFLAGS := -lstdc++ -lm -L$(LIBDIR) -lnas2d \
+CFLAGS := -std=c++11 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+LDFLAGS := -lstdc++ -lm -L$(NAS2DLIBDIR) -lnas2d \
 	$(shell sdl2-config --libs) -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf \
 	-lphysfs -lGLU -lGL -lGLEW
 

--- a/makefile
+++ b/makefile
@@ -1,15 +1,13 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
 SRCDIR := src
-INCDIR := API/NAS2D/include/
-LIBDIR := API/NAS2D/lib
-#LIBDIR := ../nas2d-core/build/lib
+INCDIR := nas2d-core/include
+LIBDIR := nas2d-core/lib
 BUILDDIR := build
-BINDIR := $(BUILDDIR)/bin
+BINDIR := .
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
-#EXE := $(BINDIR)/OPHD
-EXE := OPHD
+EXE := $(BINDIR)/OPHD
 
 CFLAGS := -std=c++11 -g -Wall -Wno-unknown-pragmas -I$(INCDIR) $(shell sdl2-config --cflags)
 LDFLAGS := -lstdc++ -lm -L$(LIBDIR) -lnas2d \

--- a/src/ProductPool.h
+++ b/src/ProductPool.h
@@ -47,7 +47,3 @@ private:
 	int					mCapacity = constants::BASE_PRODUCT_CAPACITY;
 	int					mCurrentStorageCount = 0;
 };
-
-
-int storageRequired(ProductType type, int count);
-int storageRequiredPerUnit(ProductType type);

--- a/src/States/GameState.h
+++ b/src/States/GameState.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <NAS2D\NAS2D.h>
+#include <NAS2D/NAS2D.h>
 
 class GameState : public NAS2D::State
 {

--- a/src/Templates.h
+++ b/src/Templates.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Constants.h"
+
 int storageRequired(ProductType type, int count);
 int storageRequiredPerUnit(ProductType type);
 

--- a/src/Templates.h
+++ b/src/Templates.h
@@ -1,5 +1,8 @@
 #pragma once
 
+int storageRequired(ProductType type, int count);
+int storageRequiredPerUnit(ProductType type);
+
 /**
  * Transfers products from source to destination.
  */

--- a/src/Templates.h
+++ b/src/Templates.h
@@ -8,9 +8,9 @@ void transferProducts(T& source, T& destination)
 {
 	if (source->products().empty() || destination->products().atCapacity()) { return; }
 
-	ProductPool::ProductTypeCount& src = source->products().mProducts;
+	auto& src = source->products().mProducts;
 
-	ProductPool& dest = destination->products();
+	auto& dest = destination->products();
 
 	for (size_t i = 0; i < PRODUCT_COUNT; ++i)
 	{


### PR DESCRIPTION
Add NAS2D as a Git submodule, and update the Linux makefile to account for the new project structure. Also adds rules to auto build the NAS2D library, and perform rebuilds when updated.

A standard Linux project layout will also help with automated builds and testing on CI servers.