### PR TITLE
Change Filesystem init parameters

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 	try
 	{
 		Filesystem& f = Utility<Filesystem>::get();
-		f.init(argv[0], "data");
+		f.init(argv[0], "OutpostHD", "LairWorks", "data");
 
 		if (!f.exists(constants::SAVE_GAME_PATH))
 		{


### PR DESCRIPTION
Adds `appName` and `organizationName` parameters during app init. These will be needed by `PHYSFS_setSaneConfig`, which helps set a write folder in a cross platform way, in particular affecting Linux.

Based on changes in NAS2D:
https://github.com/lairworks/nas2d-core/pull/96

The submodule update will need to be checked against other open pull requests for conflicting submodule updates. Ideally, changes in NAS2D should be merged to master first. Then apply an additional commit here to update the NAS2D submodule. That should prevent conflicts from different OPHD branches using different NAS2D submodule branches.
