### PR TITLE
Update NAS2D, including Linux path fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,8 +130,8 @@ int main(int argc, char *argv[])
 
 		std::cout << "Loading packed assets... ";
 
-		f.addToSearchPath("fonts.dat");
-		f.addToSearchPath("planets.dat");
+		f.mount("fonts.dat");
+		f.mount("planets.dat");
 
 		std::cout << "done." << std::endl;
 


### PR DESCRIPTION
Fixes set the write folder to be under the user's profile folder.

Also includes a small breaking change where `addToSearchPath` was renamed to `mount`.
