### PR TITLE
Update NAS2D dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
+      - image: outpostuniverse/nas2d-circleci:1.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: outpostuniverse/ubuntu-18.04-circleci-gcc-sdl2
+      - image: outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,4 @@ jobs:
             git submodule update
       - run:
           name: "Build"
-          command: make -k
+          command: make --keep-going

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)/include
 NAS2DLIBDIR := $(NAS2DDIR)/lib
 NAS2DLIB := $(NAS2DLIBDIR)/libnas2d.a
 
-CFLAGS := -std=c++11 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+CFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := -lstdc++ -lm -L$(NAS2DLIBDIR) -lnas2d \
 	$(shell sdl2-config --libs) -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf \
 	-lphysfs -lGLU -lGL -lGLEW


### PR DESCRIPTION
Update NAS2D dependency, and CircleCI Docker image used for builds. Target C++17 standard.
