### PR TITLE
Add enum scope

### DIFF
--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -258,7 +258,7 @@ void MainReportsUiState::_deactivate()
 void MainReportsUiState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
 {
 	if (!active()) { return; }
-	if(key == NAS2D::EventHandler::KEY_ESCAPE) { exit(); }
+	if(key == NAS2D::EventHandler::KeyCode::KEY_ESCAPE) { exit(); }
 }
 
 

--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -271,7 +271,7 @@ void MainReportsUiState::onMouseDown(EventHandler::MouseButton button, int x, in
 
 	if (!isPointInRect(x, y, 0, 0, Utility<Renderer>::get().width(), 40)) { return; } // ignore clicks in the UI area.
 
-	if (button == EventHandler::BUTTON_LEFT)
+	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		for (Panel& panel : Panels)
 		{

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -330,7 +330,7 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 		return;
 	}
 
-	if (key == EventHandler::KEY_F1)
+	if (key == EventHandler::KeyCode::KEY_F1)
 	{
 		mReportsUiCallback();
 		return;
@@ -341,77 +341,77 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 
 	switch(key)
 	{
-		case EventHandler::KEY_w:
-		case EventHandler::KEY_UP:
+		case EventHandler::KeyCode::KEY_w:
+		case EventHandler::KeyCode::KEY_UP:
 			viewUpdated = true;
 			pt.y(std::clamp(--pt.y(), 0, mTileMap->height() - mTileMap->edgeLength()));
 			break;
 
-		case EventHandler::KEY_s:
-		case EventHandler::KEY_DOWN:
+		case EventHandler::KeyCode::KEY_s:
+		case EventHandler::KeyCode::KEY_DOWN:
 			viewUpdated = true;
 			pt.y(std::clamp(++pt.y(), 0, mTileMap->height() - mTileMap->edgeLength()));
 			break;
 
-		case EventHandler::KEY_a:
-		case EventHandler::KEY_LEFT:
+		case EventHandler::KeyCode::KEY_a:
+		case EventHandler::KeyCode::KEY_LEFT:
 			viewUpdated = true;
 			pt.x(std::clamp(--pt.x(), 0, mTileMap->width() - mTileMap->edgeLength()));
 			break;
 
-		case EventHandler::KEY_d:
-		case EventHandler::KEY_RIGHT:
+		case EventHandler::KeyCode::KEY_d:
+		case EventHandler::KeyCode::KEY_RIGHT:
 			viewUpdated = true;
 			pt.x(std::clamp(++pt.x(), 0, mTileMap->width() - mTileMap->edgeLength()));
 			break;
 
-		case EventHandler::KEY_0:
+		case EventHandler::KeyCode::KEY_0:
 			viewUpdated = true;
 			changeDepth(0);
 			break;
 
-		case EventHandler::KEY_1:
+		case EventHandler::KeyCode::KEY_1:
 			viewUpdated = true;
 			changeDepth(1);
 			break;
 
-		case EventHandler::KEY_2:
+		case EventHandler::KeyCode::KEY_2:
 			viewUpdated = true;
 			changeDepth(2);
 			break;
 
-		case EventHandler::KEY_3:
+		case EventHandler::KeyCode::KEY_3:
 			viewUpdated = true;
 			changeDepth(3);
 			break;
 
-		case EventHandler::KEY_4:
+		case EventHandler::KeyCode::KEY_4:
 			viewUpdated = true;
 			changeDepth(4);
 			break;
 
-		case EventHandler::KEY_PAGEUP:
+		case EventHandler::KeyCode::KEY_PAGEUP:
 			viewUpdated = true;
 			changeDepth(mTileMap->currentDepth() - 1);
 			break;
 
-		case EventHandler::KEY_PAGEDOWN:
+		case EventHandler::KeyCode::KEY_PAGEDOWN:
 			viewUpdated = true;
 			changeDepth(mTileMap->currentDepth() + 1);
 			break;
 
 
-		case EventHandler::KEY_HOME:
+		case EventHandler::KeyCode::KEY_HOME:
 			viewUpdated = true;
 			changeDepth(0);
 			break;
 
-		case EventHandler::KEY_END:
+		case EventHandler::KeyCode::KEY_END:
 			viewUpdated = true;
 			changeDepth(mTileMap->maxDepth());
 			break;
 
-		case EventHandler::KEY_F10:
+		case EventHandler::KeyCode::KEY_F10:
 			if (Utility<EventHandler>::get().control(mod) && Utility<EventHandler>::get().shift(mod))
 			{
 				mPlayerResources.pushResource(ResourcePool::RESOURCE_COMMON_METALS, 1000);
@@ -425,24 +425,24 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 			}
 			break;
 
-		case EventHandler::KEY_F2:
+		case EventHandler::KeyCode::KEY_F2:
 			mFileIoDialog.scanDirectory(constants::SAVE_GAME_PATH);
 			mFileIoDialog.setMode(FileIo::FILE_SAVE);
 			mFileIoDialog.show();
 			break;
 
-		case EventHandler::KEY_F3:
+		case EventHandler::KeyCode::KEY_F3:
 			mFileIoDialog.scanDirectory(constants::SAVE_GAME_PATH);
 			mFileIoDialog.setMode(FileIo::FILE_LOAD);
 			mFileIoDialog.show();
 			break;
 
-		case EventHandler::KEY_ESCAPE:
+		case EventHandler::KeyCode::KEY_ESCAPE:
 			clearMode();
 			resetUi();
 			break;
 
-		case EventHandler::KEY_ENTER:
+		case EventHandler::KeyCode::KEY_ENTER:
 			if (mBtnTurns.enabled()) { nextTurn(); }
 			break;
 

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -469,13 +469,13 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if (mDiggerDirection.visible() && isPointInRect(MOUSE_COORDS, mDiggerDirection.rect())) { return; }
 
-	if (mWindowStack.pointInWindow(MOUSE_COORDS) && button == EventHandler::BUTTON_LEFT)
+	if (mWindowStack.pointInWindow(MOUSE_COORDS) && button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		mWindowStack.updateStack(MOUSE_COORDS);
 		return;
 	}
 
-	if (button == EventHandler::BUTTON_RIGHT)
+	if (button == EventHandler::MouseButton::BUTTON_RIGHT)
 	{
 		if (mWindowStack.pointInWindow(MOUSE_COORDS)) { return; }
 
@@ -530,7 +530,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		}
 	}
 
-	if (button == EventHandler::BUTTON_LEFT)
+	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		mLeftButtonDown = true;
 
@@ -605,7 +605,7 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int x, i
 {
 	if (!active()) { return; }
 
-	if (button == EventHandler::BUTTON_LEFT)
+	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		if (mWindowStack.pointInWindow(MOUSE_COORDS)) { return; }
 		if (!mTileMap->tileHighlightVisible()) { return; }
@@ -631,7 +631,7 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int x, i
 */
 void MapViewState::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
-	if (button == EventHandler::BUTTON_LEFT)
+	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		mLeftButtonDown = false;
 	}

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -101,7 +101,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 
-	if(button == EventHandler::BUTTON_LEFT)
+	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		Point_2d click(x, y);
 
@@ -125,7 +125,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
 	if(!enabled() || !visible() || !hasFocus()) { return; }
 
-	if(button == EventHandler::BUTTON_LEFT)
+	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		Point_2d click(x, y);
 		

--- a/src/UI/Core/CheckBox.cpp
+++ b/src/UI/Core/CheckBox.cpp
@@ -83,7 +83,7 @@ void CheckBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 	
-	if (button == EventHandler::BUTTON_LEFT && isPointInRect(x, y, rect().x(), rect().y(), rect().width(), rect().height()))
+	if (button == EventHandler::MouseButton::BUTTON_LEFT && isPointInRect(x, y, rect().x(), rect().y(), rect().width(), rect().height()))
 	{
 		mChecked = !mChecked;
 		mCallback();

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -90,7 +90,7 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 
-	if (button != EventHandler::BUTTON_LEFT) { return; }
+	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 
 	if (isPointInRect(Point_2d(x, y), mBaseArea))
 	{

--- a/src/UI/Core/ListBoxBase.cpp
+++ b/src/UI/Core/ListBoxBase.cpp
@@ -110,9 +110,9 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	if (!visible() || !hasFocus()) { return; }
 
-	if (empty() || button == EventHandler::BUTTON_MIDDLE) { return; }
+	if (empty() || button == EventHandler::MouseButton::BUTTON_MIDDLE) { return; }
 
-	if (button == EventHandler::BUTTON_RIGHT && isPointInRect(x, y, positionX(), positionY(), width(), height()))
+	if (button == EventHandler::MouseButton::BUTTON_RIGHT && isPointInRect(x, y, positionX(), positionY(), width(), height()))
 	{
 		setSelection(constants::NO_SELECTION);
 		return;

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -195,7 +195,7 @@ void Slider::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 
-	if (button == EventHandler::BUTTON_LEFT)
+	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		if (pointInRect_f(x, y, mSlider))
 		{
@@ -214,7 +214,7 @@ void Slider::onMouseDown(EventHandler::MouseButton button, int x, int y)
  */
 void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
-	if (button != EventHandler::BUTTON_LEFT) { return; }
+	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 	
 	mButton1Held = false;
 	mButton2Held = false;

--- a/src/UI/Core/TextField.cpp
+++ b/src/UI/Core/TextField.cpp
@@ -156,7 +156,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier m
 	switch(key)
 	{	
 		// COMMAND KEYS
-		case EventHandler::KEY_BACKSPACE:
+		case EventHandler::KeyCode::KEY_BACKSPACE:
 			if(!text().empty() && mCursorPosition > 0)
 			{
 				mCursorPosition--;
@@ -165,15 +165,15 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier m
 			}
 			break;
 
-		case EventHandler::KEY_HOME:
+		case EventHandler::KeyCode::KEY_HOME:
 			mCursorPosition = 0;
 			break;
 
-		case EventHandler::KEY_END:
+		case EventHandler::KeyCode::KEY_END:
 			mCursorPosition = text().length();
 			break;
 
-		case EventHandler::KEY_DELETE:
+		case EventHandler::KeyCode::KEY_DELETE:
 			if (text().length() > 0)
 			{
 				_text() = _text().erase(mCursorPosition, 1);
@@ -182,30 +182,30 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier m
 			break;
 
 		// ARROW KEYS
-		case EventHandler::KEY_LEFT:
+		case EventHandler::KeyCode::KEY_LEFT:
 			if(mCursorPosition > 0)
 				--mCursorPosition;
 			break;
 
-		case EventHandler::KEY_RIGHT:
+		case EventHandler::KeyCode::KEY_RIGHT:
 			if(static_cast<size_t>(mCursorPosition) < text().length())
 				++mCursorPosition;
 			break;
 
 		// KEYPAD ARROWS
-		case EventHandler::KEY_KP4:
+		case EventHandler::KeyCode::KEY_KP4:
 			if((mCursorPosition > 0) && !Utility<EventHandler>::get().query_numlock())
 				--mCursorPosition;
 			break;
 
-		case EventHandler::KEY_KP6:
+		case EventHandler::KeyCode::KEY_KP6:
 			if((static_cast<size_t>(mCursorPosition) < text().length()) && !Utility<EventHandler>::get().query_numlock())
 				++mCursorPosition;
 			break;
 
 		// IGNORE ENTER/RETURN KEY
-		case EventHandler::KEY_ENTER:
-		case EventHandler::KEY_KP_ENTER:
+		case EventHandler::KeyCode::KEY_ENTER:
+		case EventHandler::KeyCode::KEY_KP_ENTER:
 			break;
 
 		// REGULAR KEYS

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -55,7 +55,7 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	UIContainer::onMouseDown(button, x, y);
 
-	mMouseDrag = (button == EventHandler::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), WINDOW_TITLE_BAR_HEIGHT));
+	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), WINDOW_TITLE_BAR_HEIGHT));
 }
 
 

--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -86,14 +86,14 @@ void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod,
 {
 	if (!visible()) { return; }	// ignore key presses when hidden.
 
-	if (key == EventHandler::KEY_ENTER || key == EventHandler::KEY_KP_ENTER)
+	if (key == EventHandler::KeyCode::KEY_ENTER || key == EventHandler::KeyCode::KEY_KP_ENTER)
 	{
 		if (!txtFileName.empty())
 		{
 			btnFileIoClicked();
 		}
 	}
-	else if (key == EventHandler::KEY_ESCAPE)
+	else if (key == EventHandler::KeyCode::KEY_ESCAPE)
 	{
 		btnCloseClicked();
 	}

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -93,7 +93,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if (!visible() || !hasFocus()) { return; }
 
 	// Don't respond to anything unless it's the left mouse button.
-	if (button != EventHandler::BUTTON_LEFT) { return; }
+	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 
 	if (!visible())
 	{

--- a/src/UI/Reports/WarehouseReport.cpp
+++ b/src/UI/Reports/WarehouseReport.cpp
@@ -294,7 +294,7 @@ void WarehouseReport::fillListDisabled()
 void WarehouseReport::doubleClicked(EventHandler::MouseButton button, int x, int y)
 {
 	if (!visible()) { return; }
-	if (button != EventHandler::BUTTON_LEFT) { return; }
+	if (button != EventHandler::MouseButton::BUTTON_LEFT) { return; }
 
 	if (SELECTED_WAREHOUSE && isPointInRect(Point_2d(x, y), lstStructures.rect()))
 	{


### PR DESCRIPTION
Closes #120

Adds consistent scope prefix to `enum` values:
- `EventHandler::MouseButton`
- `EventHandler::KeyCode`

This is necessary for when those `enum` defintions are changed to `enum class` (already merged to NAS2D).
