### PR TITLE
Use Unicode copyright symbol encoding

### DIFF
--- a/proj/vs2019/ophd.rc
+++ b/proj/vs2019/ophd.rc
@@ -81,7 +81,7 @@ BEGIN
             VALUE "FileDescription", "OutpostHD"
             VALUE "FileVersion", "0.7.11.0"
             VALUE "InternalName", "OutpostHD"
-            VALUE "LegalCopyright", "Copyright © 2015 - 2019, Leeor Dicker"
+            VALUE "LegalCopyright", "Copyright Â© 2015 - 2019, Leeor Dicker"
             VALUE "OriginalFilename", "OPHD.EXE"
             VALUE "ProductName", "OutpostHD"
             VALUE "ProductVersion", "0.7.11.0"


### PR DESCRIPTION
Just noticed this today. Seems it was changed a few days ago by my corresponding  update to NAS2D. I didn't notice it earlier since I was working in the NAS2D submodule, so Git didn't list changes from the OPHD repository.
