### PR TITLE
Mark `SeedLander` default constructor as deleted

### DIFF
--- a/src/Things/Structures/SeedLander.h
+++ b/src/Things/Structures/SeedLander.h
@@ -9,7 +9,7 @@ public:
 	typedef NAS2D::Signals::Signal2<int, int> Callback;
 
 public:
-	SeedLander() = default;
+	SeedLander() = delete;
 	SeedLander(int x, int y):	Structure(constants::SEED_LANDER, "structures/seed_0.sprite", CLASS_LANDER),
 								mX(x), mY(y)
 	{


### PR DESCRIPTION
Closes #130

It doesn't seem to make much sense to allow the SeedLander to be default constructed. For it to be valid, it needs a location, and there is no sensible default for that.
