### PR TITLE
Reduce NAS2D includes

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -6,8 +6,6 @@
 
 #include "Things/Structures/Structure.h"
 
-#include <NAS2D/NAS2D.h>
-
 #include <iostream>
 
 #if defined(WINDOWS) || defined(WIN32)

--- a/src/Common.h
+++ b/src/Common.h
@@ -5,7 +5,9 @@
 #include <string>
 #include <vector>
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/Renderer/Rectangle.h>
+#include <NAS2D/Renderer/Color.h>
+#include <NAS2D/StringUtils.h>
 
 /**
  * Digger robot digging direction.

--- a/src/Constants/UiConstants.h
+++ b/src/Constants/UiConstants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Renderer/Color.h"
 
 #include <limits>
 

--- a/src/FontManager.h
+++ b/src/FontManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/Resources/Font.h>
 
 /**
  * A basic font table lookup manager for NAS2D::Font objects.

--- a/src/Mine.h
+++ b/src/Mine.h
@@ -3,7 +3,7 @@
 #include "Common.h"
 #include "Constants.h"
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Xml/XmlElement.h"
 
 #include <bitset>
 

--- a/src/Population/Population.cpp
+++ b/src/Population/Population.cpp
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <random>
 
-#include <NAS2D/NAS2D.h>
-
 
 const int STUDENT_TO_SCIENTIST_RATE = 35;
 

--- a/src/ProductPool.cpp
+++ b/src/ProductPool.cpp
@@ -3,8 +3,6 @@
 
 #include "ProductPool.h"
 
-#include <NAS2D/NAS2D.h>
-
 #include <algorithm>
 
 using namespace NAS2D;

--- a/src/ProductPool.h
+++ b/src/ProductPool.h
@@ -4,6 +4,8 @@
 #include "Constants.h"
 #include "Templates.h"
 
+#include <NAS2D/Xml/XmlElement.h>
+
 #include <array>
 
 

--- a/src/ResourcePool.h
+++ b/src/ResourcePool.h
@@ -2,7 +2,8 @@
 
 #include <array>
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/Xml/XmlElement.h"
 
 
 /**

--- a/src/States/GameState.h
+++ b/src/States/GameState.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/State.h>
 
 class MapViewState;
 class Structure;

--- a/src/States/MainMenuState.h
+++ b/src/States/MainMenuState.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/State.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Resources/Image.h"
 
 #include "../Constants.h"
 #include "../UI/UI.h"

--- a/src/States/MainReportsUiState.h
+++ b/src/States/MainReportsUiState.h
@@ -2,6 +2,9 @@
 
 #include "Wrapper.h"
 
+#include <vector>
+
+
 class Structure;
 
 class MainReportsUiState : public Wrapper

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
 
 #include "MapViewStateHelper.h"
 #include "MainReportsUiState.h"

--- a/src/States/MapViewState.h
+++ b/src/States/MapViewState.h
@@ -23,6 +23,8 @@
 
 #include "../UI/Gui.h"
 
+#include <string>
+
 using namespace NAS2D;
 
 /**

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -10,6 +10,8 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include <string>
+#include <vector>
 #include <algorithm>
 
 extern Rectangle_2d MENU_ICON;

--- a/src/States/MapViewStateIO.cpp
+++ b/src/States/MapViewStateIO.cpp
@@ -14,6 +14,12 @@
 #include "../StructureCatalogue.h"
 #include "../StructureTranslator.h"
 
+#include <map>
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <iostream>
+
 
 using namespace NAS2D;
 using namespace NAS2D::Xml;

--- a/src/States/MapViewStateTurn.cpp
+++ b/src/States/MapViewStateTurn.cpp
@@ -10,6 +10,7 @@
 
 #include "../Things/Structures/Structures.h"
 
+#include <vector>
 #include <algorithm>
 
 

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -3,6 +3,10 @@
 
 #include "Planet.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 #include <array>
 
 

--- a/src/States/Planet.h
+++ b/src/States/Planet.h
@@ -2,7 +2,10 @@
 
 #include <cmath>
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/Signal.h>
+#include <NAS2D/Timer.h>
+#include <NAS2D/Renderer/Point.h>
+#include <NAS2D/Resources/Image.h>
 
 #include "../Constants.h"
 

--- a/src/States/PlanetSelectState.h
+++ b/src/States/PlanetSelectState.h
@@ -12,6 +12,8 @@
 
 #include "../UI/UI.h"
 
+#include <vector>
+
 
 class PlanetSelectState : public NAS2D::State
 {

--- a/src/States/PlanetSelectState.h
+++ b/src/States/PlanetSelectState.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/State.h"
+#include "NAS2D/Timer.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Resources/Image.h"
+#include "NAS2D/Resources/Music.h"
+#include "NAS2D/Resources/Sound.h"
+#include "NAS2D/Renderer/Point.h"
 
 #include "Planet.h"
 

--- a/src/States/SplashState.cpp
+++ b/src/States/SplashState.cpp
@@ -5,6 +5,9 @@
 
 #include "MainMenuState.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 #include <algorithm>
 
 const int PAUSE_TIME = 5800;

--- a/src/States/SplashState.h
+++ b/src/States/SplashState.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/State.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Timer.h"
+#include "NAS2D/Renderer/Point.h"
+#include "NAS2D/Resources/Image.h"
 
 
 #include "../Constants.h"

--- a/src/States/Wrapper.h
+++ b/src/States/Wrapper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/State.h>
 
 #include <stack>
 

--- a/src/Things/Thing.h
+++ b/src/Things/Thing.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/Resources/Sprite.h"
 
 class Tile;
 

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -7,6 +7,10 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 using namespace NAS2D;
 
 

--- a/src/UI/Core/Button.h
+++ b/src/UI/Core/Button.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Resources/Image.h"
+#include "NAS2D/Resources/Font.h"
 
 #include "Control.h"
 

--- a/src/UI/Core/CheckBox.cpp
+++ b/src/UI/Core/CheckBox.cpp
@@ -20,6 +20,10 @@
 #include"../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 #include <algorithm>
 
 

--- a/src/UI/Core/CheckBox.h
+++ b/src/UI/Core/CheckBox.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Resources/Image.h"
 
 #include "Control.h"
 

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -3,6 +3,9 @@
 
 #include "ComboBox.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/MathUtils.h"
+
 using namespace NAS2D;
 
 /**

--- a/src/UI/Core/ComboBox.h
+++ b/src/UI/Core/ComboBox.h
@@ -3,6 +3,10 @@
 #include "ListBox.h"
 #include "TextField.h"
 
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Renderer/Rectangle.h"
+
 class ComboBox : public Control
 {
 public:

--- a/src/UI/Core/Control.h
+++ b/src/UI/Core/Control.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/Renderer/Point.h"
+#include "NAS2D/Renderer/Rectangle.h"
 
 /**
  * \class Control

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -6,6 +6,10 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 using namespace NAS2D;
 
 

--- a/src/UI/Core/ListBox.h
+++ b/src/UI/Core/ListBox.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Renderer/Color.h"
 
 #include <map>
 #include <string>

--- a/src/UI/Core/ListBoxBase.cpp
+++ b/src/UI/Core/ListBoxBase.cpp
@@ -5,6 +5,10 @@
 
 #include "../../Constants.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 #include <algorithm>
 
 

--- a/src/UI/Core/ListBoxBase.h
+++ b/src/UI/Core/ListBoxBase.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Renderer/Point.h"
+#include "NAS2D/Renderer/Color.h"
 
 #include "UIContainer.h"
 #include "Slider.h"

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -11,6 +11,9 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 #include <algorithm>
 
 using namespace NAS2D;

--- a/src/UI/Core/Slider.h
+++ b/src/UI/Core/Slider.h
@@ -8,6 +8,7 @@
 #include "Control.h"
 #include "../../Common.h"
 
+#include "NAS2D/Timer.h"
 
  /**
  * \class	Slider

--- a/src/UI/Core/TextArea.cpp
+++ b/src/UI/Core/TextArea.cpp
@@ -7,6 +7,9 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 

--- a/src/UI/Core/TextArea.h
+++ b/src/UI/Core/TextArea.h
@@ -2,7 +2,8 @@
 
 #include "Control.h"
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Renderer/Color.h"
+#include "NAS2D/Resources/Font.h"
 
 #include <string>
 

--- a/src/UI/Core/TextField.cpp
+++ b/src/UI/Core/TextField.cpp
@@ -13,6 +13,10 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 #include <locale>
 
 using namespace NAS2D;

--- a/src/UI/Core/TextField.h
+++ b/src/UI/Core/TextField.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Timer.h"
+#include "NAS2D/Resources/Image.h"
 #include "Control.h"
 
 

--- a/src/UI/Core/UIContainer.cpp
+++ b/src/UI/Core/UIContainer.cpp
@@ -5,6 +5,8 @@
 
 #include "../../Common.h"
 
+#include "NAS2D/Utility.h"
+
 #include <algorithm>
 #include <iostream>
 

--- a/src/UI/Core/UIContainer.h
+++ b/src/UI/Core/UIContainer.h
@@ -2,6 +2,9 @@
 
 #include "Control.h"
 
+#include "NAS2D/EventHandler.h"
+
+#include <vector>
 
 /**
  * UI Object that contains other UI Control's.

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -7,6 +7,9 @@
 #include "../../Constants.h"
 #include "../../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 const float WINDOW_TITLE_BAR_HEIGHT = 20.0f;

--- a/src/UI/Core/Window.h
+++ b/src/UI/Core/Window.h
@@ -2,6 +2,8 @@
 
 #include "UIContainer.h"
 
+#include "NAS2D/Resources/Image.h"
+
 class Window : public UIContainer
 {
 public:

--- a/src/UI/FactoryListBox.h
+++ b/src/UI/FactoryListBox.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
+#include "NAS2D/Renderer/Point.h"
 
 #include "Core/ListBoxBase.h"
 

--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -5,6 +5,10 @@
 
 #include "../Constants.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Filesystem.h"
+#include "NAS2D/MathUtils.h"
+
 using namespace NAS2D;
 
 

--- a/src/UI/FileIo.h
+++ b/src/UI/FileIo.h
@@ -2,6 +2,9 @@
 
 #include "UI.h"
 
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+
 
 class FileIo : public Window
 {

--- a/src/UI/GameOverDialog.cpp
+++ b/src/UI/GameOverDialog.cpp
@@ -6,6 +6,9 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -6,6 +6,10 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/MathUtils.h"
+
 using namespace NAS2D;
 
 static Font* FONT = nullptr;

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -2,6 +2,12 @@
 
 #include "UI.h"
 
+#include "NAS2D/Signal.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Renderer/Point.h"
+#include "NAS2D/Resources/Image.h"
+
+
 #include <algorithm>
 
 /**

--- a/src/UI/MajorEventAnnouncement.cpp
+++ b/src/UI/MajorEventAnnouncement.cpp
@@ -6,6 +6,9 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 MajorEventAnnouncement::MajorEventAnnouncement()

--- a/src/UI/MajorEventAnnouncement.h
+++ b/src/UI/MajorEventAnnouncement.h
@@ -2,6 +2,8 @@
 
 #include "UI.h"
 
+#include "NAS2D/Resources/Image.h"
+
 class MajorEventAnnouncement : public Window
 {
 public:

--- a/src/UI/PopulationPanel.cpp
+++ b/src/UI/PopulationPanel.cpp
@@ -6,6 +6,9 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
 using namespace NAS2D;
 
 static Font* FONT = nullptr;

--- a/src/UI/ProductListBox.cpp
+++ b/src/UI/ProductListBox.cpp
@@ -7,6 +7,10 @@
 #include "../FontManager.h"
 #include "../ProductPool.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+
+
 using namespace NAS2D;
 
 

--- a/src/UI/ProductListBox.h
+++ b/src/UI/ProductListBox.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
 #include "Core/ListBoxBase.h"
 
 class ProductPool;

--- a/src/UI/ResourceBreakdownPanel.cpp
+++ b/src/UI/ResourceBreakdownPanel.cpp
@@ -6,6 +6,10 @@
 #include "../Constants.h"
 #include "../FontManager.h"
 
+#include "NAS2D/Utility.h"
+#include "NAS2D/Renderer/Renderer.h"
+#include "NAS2D/StringUtils.h"
+
 using namespace NAS2D;
 
 static Font* FONT = nullptr;

--- a/src/UI/ResourceBreakdownPanel.h
+++ b/src/UI/ResourceBreakdownPanel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "NAS2D/Resources/Image.h"
+
 #include "Core/Control.h"
 #include "../ResourcePool.h"
 

--- a/src/UI/StructureListBox.h
+++ b/src/UI/StructureListBox.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Signal.h"
 
 #include "Core/ListBoxBase.h"
 

--- a/src/WindowEventWrapper.h
+++ b/src/WindowEventWrapper.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/Utility.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Configuration.h"
 
 #include "Common.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check it.
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-#include "NAS2D/NAS2D.h"
-
+#include "NAS2D/Resources/Image.h"
+#include "NAS2D/Resources/Music.h"
 #include "NAS2D/Mixer/MixerSDL.h"
 #include "NAS2D/Mixer/MixerNull.h"
 #include "NAS2D/Renderer/RendererOpenGL.h"


### PR DESCRIPTION
Closes #134

Replaces `#include "NAS2D.h"` with more specific includes.

In a few places, it was found some headers were being used without being directly imported. Imports for these headers were added so they would no longer be dependent on indirect includes. Addition of missing includes was largely focused on resolving immediate errors, or obvious omission in related code. Issue #138 was created to address any remaining cleanup.
