### PR TITLE
Remove uses of Rectangle `operator()`

### DIFF
--- a/src/Map/TileMap.cpp
+++ b/src/Map/TileMap.cpp
@@ -289,7 +289,7 @@ void TileMap::initMapDrawParams(int w, int h)
 	mEdgeLength = w / TILE_WIDTH;
 
 	mMapPosition((w / 2 - (TILE_WIDTH / 2)), ((h - constants::BOTTOM_UI_HEIGHT) / 2) - ((static_cast<float>(mEdgeLength) / 2) * TILE_HEIGHT_ABSOLUTE));
-	mMapBoundingBox((w / 2) - ((TILE_WIDTH * mEdgeLength) / 2), mMapPosition.y(), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength);
+	mMapBoundingBox = {(w / 2) - ((TILE_WIDTH * mEdgeLength) / 2), static_cast<int>(mMapPosition.y()), TILE_WIDTH * mEdgeLength, TILE_HEIGHT_ABSOLUTE * mEdgeLength};
 
 	int transform = (mMapPosition.x() - mMapBoundingBox.x()) / TILE_WIDTH;
 	TRANSFORM(-transform, transform);

--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -81,7 +81,7 @@ static std::array<Panel, PANEL_COUNT> Panels;	/**< Array of UI navigation panels
  */
 static void setPanelRects(int width)
 {
-	Panels[PANEL_EXIT].Rect(width - 48, 0, 48, 48);
+	Panels[PANEL_EXIT].Rect = {width - 48, 0, 48, 48};
 	Panels[PANEL_EXIT].IconPosition(width - 40, 8);
 	
 	int remaining_width = width - Panels[PANEL_EXIT].Rect.width();
@@ -89,33 +89,33 @@ static void setPanelRects(int width)
 	int text_y_position = 24 - BIG_FONT->height() / 2;
 
 	
-	Panels[PANEL_RESEARCH].Rect(0, 0, panel_width, 48);
+	Panels[PANEL_RESEARCH].Rect = {0, 0, panel_width, 48};
 	Panels[PANEL_RESEARCH].TextPosition(panel_width / 2 - BIG_FONT->width(Panels[PANEL_RESEARCH].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_RESEARCH].IconPosition(Panels[PANEL_RESEARCH].TextPosition.x() - 40, 8);
 
 	
-	Panels[PANEL_PRODUCTION].Rect(Panels[PANEL_RESEARCH].Rect.x() + panel_width, 0, panel_width, 48);
+	Panels[PANEL_PRODUCTION].Rect = {Panels[PANEL_RESEARCH].Rect.x() + panel_width, 0, panel_width, 48};
 	Panels[PANEL_PRODUCTION].TextPosition(Panels[PANEL_PRODUCTION].Rect.x() + panel_width / 2 - BIG_FONT->width(Panels[PANEL_PRODUCTION].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_PRODUCTION].IconPosition(Panels[PANEL_PRODUCTION].TextPosition.x() - 40, 8);
 	//Panels[PANEL_PRODUCTION].Selected(true);
 
 
-	Panels[PANEL_WAREHOUSE].Rect(Panels[PANEL_PRODUCTION].Rect.x() + panel_width, 0, panel_width, 48);
+	Panels[PANEL_WAREHOUSE].Rect = {Panels[PANEL_PRODUCTION].Rect.x() + panel_width, 0, panel_width, 48};
 	Panels[PANEL_WAREHOUSE].TextPosition(Panels[PANEL_WAREHOUSE].Rect.x() + panel_width / 2 - BIG_FONT->width(Panels[PANEL_WAREHOUSE].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_WAREHOUSE].IconPosition(Panels[PANEL_WAREHOUSE].TextPosition.x() - 40, 8);
 
 
-	Panels[PANEL_MINING].Rect(Panels[PANEL_WAREHOUSE].Rect.x() + panel_width, 0, panel_width, 48);
+	Panels[PANEL_MINING].Rect = {Panels[PANEL_WAREHOUSE].Rect.x() + panel_width, 0, panel_width, 48};
 	Panels[PANEL_MINING].TextPosition(Panels[PANEL_MINING].Rect.x() + panel_width / 2 - BIG_FONT->width(Panels[PANEL_MINING].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_MINING].IconPosition(Panels[PANEL_MINING].TextPosition.x() - 40, 8);
 
 	
-	Panels[PANEL_SATELLITES].Rect(Panels[PANEL_MINING].Rect.x() + panel_width, 0, panel_width, 48);
+	Panels[PANEL_SATELLITES].Rect = {Panels[PANEL_MINING].Rect.x() + panel_width, 0, panel_width, 48};
 	Panels[PANEL_SATELLITES].TextPosition(Panels[PANEL_SATELLITES].Rect.x() + panel_width / 2 - BIG_FONT->width(Panels[PANEL_SATELLITES].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_SATELLITES].IconPosition(Panels[PANEL_SATELLITES].TextPosition.x() - 40, 8);
 
 	
-	Panels[PANEL_SPACEPORT].Rect(Panels[PANEL_SATELLITES].Rect.x() + panel_width, 0, panel_width, 48);
+	Panels[PANEL_SPACEPORT].Rect = {Panels[PANEL_SATELLITES].Rect.x() + panel_width, 0, panel_width, 48};
 	Panels[PANEL_SPACEPORT].TextPosition(Panels[PANEL_SPACEPORT].Rect.x() + panel_width / 2 - BIG_FONT->width(Panels[PANEL_SPACEPORT].Name) / 2 + 20, text_y_position);
 	Panels[PANEL_SPACEPORT].IconPosition(Panels[PANEL_SPACEPORT].TextPosition.x() - 40, 8);
 }

--- a/src/States/MapViewStateUi.cpp
+++ b/src/States/MapViewStateUi.cpp
@@ -120,7 +120,7 @@ void MapViewState::initUi()
 	mWindowStack.addWindow(&mWarehouseInspector);
 	mWindowStack.addWindow(&mMineOperationsWindow);
 
-	BOTTOM_UI_AREA(0, static_cast<int>(r.height() - constants::BOTTOM_UI_HEIGHT), static_cast<int>(r.width()), constants::BOTTOM_UI_HEIGHT);
+	BOTTOM_UI_AREA = {0, static_cast<int>(r.height() - constants::BOTTOM_UI_HEIGHT), static_cast<int>(r.width()), constants::BOTTOM_UI_HEIGHT};
 
 	// BUTTONS
 	mBtnTurns.image("ui/icons/turns.png");
@@ -175,24 +175,24 @@ void MapViewState::setupUiPositions(int w, int h)
 	//Renderer& r = Utility<Renderer>::get();
 
 	// Bottom UI Area
-	BOTTOM_UI_AREA(0, static_cast<int>(h - constants::BOTTOM_UI_HEIGHT), static_cast<int>(w), constants::BOTTOM_UI_HEIGHT);
+	BOTTOM_UI_AREA = {0, static_cast<int>(h - constants::BOTTOM_UI_HEIGHT), static_cast<int>(w), constants::BOTTOM_UI_HEIGHT};
 
 	// Menu / System Icon
-	MENU_ICON(w - constants::MARGIN_TIGHT * 2 - constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2);
+	MENU_ICON = {w - constants::MARGIN_TIGHT * 2 - constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2, constants::RESOURCE_ICON_SIZE + constants::MARGIN_TIGHT * 2};
 
 	// NAVIGATION BUTTONS
 	// Bottom line
-	MOVE_DOWN_ICON(w - constants::MARGIN - 32, h - constants::BOTTOM_UI_HEIGHT - 65, 32, 32);
-	MOVE_EAST_ICON(MOVE_DOWN_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16);
-	MOVE_SOUTH_ICON(MOVE_DOWN_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16);
+	MOVE_DOWN_ICON = {w - constants::MARGIN - 32, h - constants::BOTTOM_UI_HEIGHT - 65, 32, 32};
+	MOVE_EAST_ICON = {MOVE_DOWN_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
+	MOVE_SOUTH_ICON = {MOVE_DOWN_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_DOWN_ICON.y() + 8, 32, 16};
 
 	// Top line
-	MOVE_UP_ICON(MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y() - constants::MARGIN_TIGHT - 32, 32, 32);
-	MOVE_NORTH_ICON(MOVE_UP_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16);
-	MOVE_WEST_ICON(MOVE_UP_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16);
+	MOVE_UP_ICON = {MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y() - constants::MARGIN_TIGHT - 32, 32, 32};
+	MOVE_NORTH_ICON = {MOVE_UP_ICON.x() - (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16};
+	MOVE_WEST_ICON = {MOVE_UP_ICON.x() - 2 * (32 + constants::MARGIN_TIGHT), MOVE_UP_ICON.y() + 8, 32, 16};
 
 	// Mini Map
-	mMiniMapBoundingBox(static_cast<int>(w - 300 - constants::MARGIN), static_cast<int>(BOTTOM_UI_AREA.y() + constants::MARGIN), 300, 150);
+	mMiniMapBoundingBox = {static_cast<int>(w - 300 - constants::MARGIN), static_cast<int>(BOTTOM_UI_AREA.y() + constants::MARGIN), 300, 150};
 
 	// Position UI Buttons
 	mBtnTurns.position(static_cast<float>(mMiniMapBoundingBox.x() - constants::MAIN_BUTTON_SIZE - constants::MARGIN_TIGHT), static_cast<float>(h - constants::MARGIN - MAIN_BUTTON_SIZE));

--- a/src/UI/Core/CheckBox.cpp
+++ b/src/UI/Core/CheckBox.cpp
@@ -109,8 +109,8 @@ void CheckBox::onTextChanged()
  */
 void CheckBox::onSizeChanged()
 {
-	_rect().height(std::clamp(height(), 13.0f, 13.0f));
-	if (width() < 13.0f) { _rect().width(13.0f); }
+	mRect.height(std::clamp(height(), 13.0f, 13.0f));
+	if (width() < 13.0f) { mRect.width(13.0f); }
 }
 
 

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -66,7 +66,7 @@ void ComboBox::resizedHandler(Control* c)
 	lstItems.width(width());
 	lstItems.position(positionX(), positionY() + height());
 
-	mBaseArea(positionX(), positionY(), width(), btnDown.height());
+	mBaseArea = {positionX(), positionY(), width(), btnDown.height()};
 }
 
 
@@ -79,7 +79,7 @@ void ComboBox::repositioned(float, float)
 	txtField.position(positionX(), positionY());
 	lstItems.position(positionX(), positionY() + height());
 
-	mBaseArea(positionX(), positionY(), width(), btnDown.height());
+	mBaseArea = {positionX(), positionY(), width(), btnDown.height()};
 }
 
 

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -95,7 +95,14 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if (isPointInRect(Point_2d(x, y), mBaseArea))
 	{
 		lstItems.visible(!lstItems.visible());
-		lstItems.visible() ? mRect.height(height() + lstItems.height()) : mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+		if (lstItems.visible())
+		{
+			mRect.height(height() + lstItems.height());
+		}
+		else
+		{
+			mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+		}
 	}
 	else if (!isPointInRect(Point_2d(x, y), lstItems.rect()))
 	{

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -101,13 +101,13 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 		}
 		else
 		{
-			mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+			mRect = {mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height()};
 		}
 	}
 	else if (!isPointInRect(Point_2d(x, y), lstItems.rect()))
 	{
 		lstItems.visible(false);
-		mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+		mRect = {mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height()};
 	}
 }
 
@@ -132,7 +132,7 @@ void ComboBox::lstItemsSelectionChanged()
 {
 	txtField.text(lstItems.selectionText());
 	lstItems.visible(false);
-	mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+	mRect = {mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height()};
 	mSelectionChanged();
 }
 

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -95,12 +95,12 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if (isPointInRect(Point_2d(x, y), mBaseArea))
 	{
 		lstItems.visible(!lstItems.visible());
-		lstItems.visible() ? _rect().height(height() + lstItems.height()) : _rect()(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+		lstItems.visible() ? mRect.height(height() + lstItems.height()) : mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
 	}
 	else if (!isPointInRect(Point_2d(x, y), lstItems.rect()))
 	{
 		lstItems.visible(false);
-		_rect()(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+		mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
 	}
 }
 
@@ -125,7 +125,7 @@ void ComboBox::lstItemsSelectionChanged()
 {
 	txtField.text(lstItems.selectionText());
 	lstItems.visible(false);
-	_rect()(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
+	mRect(mBaseArea.x(), mBaseArea.y(), mBaseArea.width(), mBaseArea.height());
 	mSelectionChanged();
 }
 

--- a/src/UI/Core/Control.cpp
+++ b/src/UI/Core/Control.cpp
@@ -271,19 +271,6 @@ Control::TextChangedCallback& Control::textChanged()
 
 
 /**
- * Internal version of the rect() function which allows
- * non-const access to the rectangle information.
- * 
- * \note	This is an internal function and may not be
- *			called outside of the Control class.
- */
-Rectangle_2df& Control::_rect()
-{
-	return mRect;
-}
-
-
-/**
  * Internal version of the text() function which allows
  * non-const access to the text contained in the Control.
  * 

--- a/src/UI/Core/Control.h
+++ b/src/UI/Core/Control.h
@@ -81,7 +81,6 @@ protected:
 	virtual void onSizeChanged() { mResized(this); }
 	virtual void onTextChanged() { mTextChanged(this); };
 
-	NAS2D::Rectangle_2df& _rect();
 	std::string& _text();
 
 protected:
@@ -89,13 +88,13 @@ protected:
 	ResizeCallback				mResized;
 	TextChangedCallback			mTextChanged;
 
+	NAS2D::Rectangle_2df	mRect;				/**< Area of the Control. */
+
 private:
 	virtual void draw() {};
 
 private:
 	std::string				mText;				/**< Internal text string. */
-
-	NAS2D::Rectangle_2df	mRect;				/**< Area of the Control. */
 
 	bool					mEnabled = true;	/**< Flag indicating whether or not the Control is enabled. */
 	bool					mHasFocus = false;	/**< Flag indicating that the Control has input focus. */

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -330,10 +330,12 @@ void FactoryReport::resized(Control* c)
 
 	lstFactoryList.size(FACTORY_LISTBOX.width(), FACTORY_LISTBOX.height());
 
-	DETAIL_PANEL(cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 20,
+	DETAIL_PANEL = {
+		cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width() + 20,
 		rect().y() + 10,
 		rect().width() - (cboFilterByProduct.rect().x() + cboFilterByProduct.rect().width()) - 30,
-		rect().y() + rect().height() - 69);
+		rect().y() + rect().height() - 69
+	};
 
 	STATUS_LABEL_POSITION = DETAIL_PANEL.x() + FONT_MED_BOLD->width("Status") + 158.0f;
 	


### PR DESCRIPTION
This is in preparation for upstream change: https://github.com/lairworks/nas2d-core/issues/337

This addresses changes involving the Rectangle classes. Changes for the Point class will follow later.
