### PR TITLE
Replace supposedly evil code

### DIFF
--- a/src/States/PlanetSelectState.cpp
+++ b/src/States/PlanetSelectState.cpp
@@ -32,7 +32,7 @@ public:
 
 		if (mTimer.accumulator() > 7)
 		{
-			mFrame = ++mFrame >= 64 ? 0 : mFrame;	/// yeesh, this is evil.
+			mFrame = (mFrame + 1) % 64;
 			mTimer.reset();
 		}
 


### PR DESCRIPTION
I believe this is the idiom you are looking for.

----

Also, I'm not sure the original code had well defined behaviour. It updated `mFrame` as both a side effect of the `++mFrame` and as a direct effect of the assignment `mFrame = `. You'd have to read up on sequence points to know for sure, though I suspect the two stores are unsequenced.

Evaluating the result of `++mFrame` is a different matter, which must be done before the `>=` comparison. This is different from storing the result of `++mFrame`.
