### PR TITLE
Fix warnings pass

### DIFF
--- a/src/GraphWalker.cpp
+++ b/src/GraphWalker.cpp
@@ -39,7 +39,7 @@ static bool validConnection(Structure* src, Structure* dst, Direction _d)
 	if (src == nullptr || dst == nullptr)
 	{
 		#ifdef DEBUG
-		throw std::runtime_error("GraphWalker::validConnection() was passed a NULL Pointer.");
+		std::cout << "GraphWalker::validConnection() was passed a NULL Pointer." << std::endl;
 		#endif
 		return false;
 	}

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -79,7 +79,7 @@ public:
 	/** MicroPather public interface implementation. */
 	virtual float LeastCostEstimate(void* stateStart, void* stateEnd);
 	virtual void AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent);
-	virtual void PrintStateInfo(void* state) {};
+	virtual void PrintStateInfo(void* /*state*/) { /* DO NOTHING */ };
 
 protected:
 	/**

--- a/src/Map/TileMap.h
+++ b/src/Map/TileMap.h
@@ -79,7 +79,7 @@ public:
 	/** MicroPather public interface implementation. */
 	virtual float LeastCostEstimate(void* stateStart, void* stateEnd);
 	virtual void AdjacentCost(void* state, std::vector<micropather::StateCost>* adjacent);
-	virtual void PrintStateInfo(void* /*state*/) { /* DO NOTHING */ };
+	virtual void PrintStateInfo(void* /*state*/) {};
 
 protected:
 	/**

--- a/src/Mine.cpp
+++ b/src/Mine.cpp
@@ -184,7 +184,7 @@ void Mine::increaseDepth()
  */
 int Mine::depth() const
 {
-	return mVeins.size();
+	return static_cast<int>(mVeins.size());
 }
 
 

--- a/src/Mine.cpp
+++ b/src/Mine.cpp
@@ -346,7 +346,7 @@ void Mine::deserialize(NAS2D::Xml::XmlElement* _ti)
 	mVeins.resize(depth);
 	for (XmlNode* vein = _ti->firstChild(); vein != nullptr; vein = vein->nextSibling())
 	{
-		MineVein _mv;
+		MineVein _mv = MineVein{0, 0, 0, 0};
 		attribute = vein->toElement()->firstAttribute();
 		int id = 0;
 		while (attribute)

--- a/src/Population/Morale.h
+++ b/src/Population/Morale.h
@@ -5,19 +5,16 @@
 /**
  * Morale modifier values.
  */
-class MoraleModifier
+struct MoraleModifier
 {
 public:
-	MoraleModifier(uint32_t rBonus, uint32_t pBonus, uint32_t fRate, uint32_t mRate) :
+	MoraleModifier() = default;
+	MoraleModifier(int rBonus, int pBonus, int fRate, int mRate) :
 		researchBonus(rBonus), productionBonus(pBonus), fertilityRate(fRate), mortalityRate(mRate)
 	{}
 
-	MoraleModifier() : researchBonus(0), productionBonus(0), fertilityRate(0), mortalityRate(0)
-	{}
-
-public:
-	int researchBonus;
-	int productionBonus;
-	int fertilityRate;
-	int mortalityRate;
+	int researchBonus{0};
+	int productionBonus{0};
+	int fertilityRate{0};
+	int mortalityRate{0};
 };

--- a/src/RobotPool.cpp
+++ b/src/RobotPool.cpp
@@ -147,17 +147,17 @@ bool RobotPool::robotAvailable(RobotType _type)
 		return getDigger() != nullptr;
 	}
 	case ROBOT_DOZER:
-    {
-        return getDozer() != nullptr;
-    }
+	{
+		return getDozer() != nullptr;
+	}
 	case ROBOT_MINER:
-    {
-        return getMiner() != nullptr;
-    }
+	{
+		return getMiner() != nullptr;
+	}
 	default:
-    {
-        return false;
-    }
+	{
+		return false;
+	}
 	}
 }
 

--- a/src/RobotPool.cpp
+++ b/src/RobotPool.cpp
@@ -143,23 +143,22 @@ bool RobotPool::robotAvailable(RobotType _type)
 	switch (_type)
 	{
 	case ROBOT_DIGGER:
+	{
 		return getDigger() != nullptr;
-		break;
-
-	case ROBOT_DOZER:
-		return getDozer() != nullptr;
-		break;
-
-	case ROBOT_MINER:
-		return getMiner() != nullptr;
-		break;
-
-	default:
-		return false;
-		break;
 	}
-
-	return false;
+	case ROBOT_DOZER:
+    {
+        return getDozer() != nullptr;
+    }
+	case ROBOT_MINER:
+    {
+        return getMiner() != nullptr;
+    }
+	default:
+    {
+        return false;
+    }
+	}
 }
 
 

--- a/src/States/GameState.cpp
+++ b/src/States/GameState.cpp
@@ -101,7 +101,7 @@ void GameState::mapviewstate(MapViewState* state)
 /**
  * Mouse motion event handler.
  */
-void GameState::onMouseMotion(int x, int y, int relX, int relY)
+void GameState::onMouseMotion(int x, int y, int /*relX*/, int /*relY*/)
 {
 	MOUSE_COORDS = {x, y};
 }

--- a/src/States/MainMenuState.cpp
+++ b/src/States/MainMenuState.cpp
@@ -101,16 +101,16 @@ void MainMenuState::positionButtons()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	int start_x = r.center_x() - 100;
-	int start_y = r.center_y() - ((35 * 4) / 2);
+	float start_x = r.center_x() - 100.0f;
+	float start_y = r.center_y() - ((35.0f * 4.0f) / 2.0f);
 
 	btnNewGame.position(start_x, start_y);
-	btnContinueGame.position(start_x, start_y + 35);
-	btnOptions.position(start_x, start_y + 70);
-	btnHelp.position(start_x, start_y + 105);
-	btnQuit.position(start_x, start_y + 140);
+	btnContinueGame.position(start_x, start_y + 35.0f);
+	btnOptions.position(start_x, start_y + 70.0f);
+	btnHelp.position(start_x, start_y + 105.0f);
+	btnQuit.position(start_x, start_y + 140.0f);
 
-	mFileIoDialog.position(static_cast<int>(r.center_x() - mFileIoDialog.width() / 2), static_cast<int>(r.center_y() - mFileIoDialog.height() / 2));
+	mFileIoDialog.position(r.center_x() - mFileIoDialog.width() / 2.0f, r.center_y() - mFileIoDialog.height() / 2.0f);
 }
 
 

--- a/src/States/MainMenuState.cpp
+++ b/src/States/MainMenuState.cpp
@@ -182,14 +182,14 @@ void MainMenuState::fileIoAction(const std::string& _file, FileIo::FileOperation
 /**
  * Key down event handler.
  */
-void MainMenuState::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat)
+void MainMenuState::onKeyDown(NAS2D::EventHandler::KeyCode /*key*/, NAS2D::EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {}
 
 
 /**
  * Window resize event handler.
  */
-void MainMenuState::onWindowResized(int width, int height)
+void MainMenuState::onWindowResized(int /*width*/, int /*height*/)
 {
 	positionButtons();
 }

--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -255,7 +255,7 @@ void MainReportsUiState::_deactivate()
 /**
  * Key down event handler.
  */
-void MainReportsUiState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void MainReportsUiState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!active()) { return; }
 	if(key == NAS2D::EventHandler::KeyCode::KEY_ESCAPE) { exit(); }
@@ -352,7 +352,7 @@ void MainReportsUiState::selectWarehousePanel(Structure* structure)
 /**
  * Structure pointer is assumed to be a Mine Facility or Smelter.
  */
-void MainReportsUiState::selectMinePanel(Structure* structure)
+void MainReportsUiState::selectMinePanel(Structure* /*structure*/)
 {
 	deselectAllPanels();
 	Panels[PANEL_MINING].Selected(true);

--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -134,13 +134,13 @@ static void drawPanel(Renderer& _r, Panel& _p)
 
 		if (_p.UiPanel) { _p.UiPanel->update(); }
 
-		_r.drawText(*BIG_FONT_BOLD, _p.Name, _p.TextPosition.x(), _p.TextPosition.y(), 185, 185, 0);
-		_r.drawImage(*_p.Img, _p.IconPosition.x(), _p.IconPosition.y(), 1.0f, 185, 185, 0, 255);
+		_r.drawText(*BIG_FONT_BOLD, _p.Name, static_cast<float>(_p.TextPosition.x()), static_cast<float>(_p.TextPosition.y()), 185, 185, 0);
+		_r.drawImage(*_p.Img, static_cast<float>(_p.IconPosition.x()), static_cast<float>(_p.IconPosition.y()), 1.0f, 185, 185, 0, 255);
 	}
 	else
 	{
-		_r.drawText(*BIG_FONT_BOLD, _p.Name, _p.TextPosition.x(), _p.TextPosition.y(), 0, 185, 0);
-		_r.drawImage(*_p.Img, _p.IconPosition.x(), _p.IconPosition.y(), 1.0f, 0, 185, 0, 255);
+		_r.drawText(*BIG_FONT_BOLD, _p.Name, static_cast<float>(_p.TextPosition.x()), static_cast<float>(_p.TextPosition.y()), 0, 185, 0);
+		_r.drawImage(*_p.Img, static_cast<float>(_p.IconPosition.x()), static_cast<float>(_p.IconPosition.y()), 1.0f, 0, 185, 0, 255);
 	}
 }
 
@@ -206,7 +206,7 @@ void MainReportsUiState::initialize()
 	Panels[PANEL_SPACEPORT].Name = "Space Ports";
 
 	Renderer& r = Utility<Renderer>::get();
-	setPanelRects(r.width());
+	setPanelRects(static_cast<int>(std::floor(r.width())));
 
 	// INIT UI REPORT PANELS
 	ReportInterface* factory_report = new FactoryReport();
@@ -269,7 +269,7 @@ void MainReportsUiState::onMouseDown(EventHandler::MouseButton button, int x, in
 {
 	if (!active()) { return; }
 
-	if (!isPointInRect(x, y, 0, 0, Utility<Renderer>::get().width(), 40)) { return; } // ignore clicks in the UI area.
+	if (!isPointInRect(x, y, 0, 0, static_cast<int>(Utility<Renderer>::get().width()), 40)) { return; } // ignore clicks in the UI area.
 
 	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
@@ -309,7 +309,7 @@ void MainReportsUiState::exit()
 void MainReportsUiState::onWindowResized(int w, int h)
 {
 	setPanelRects(w);
-	for (Panel& panel : Panels) { if (panel.UiPanel) { panel.UiPanel->size(w, h - 48); } }
+	for (Panel& panel : Panels) { if (panel.UiPanel) { panel.UiPanel->size(static_cast<float>(w), h - 48.0f); } }
 }
 
 

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -302,7 +302,7 @@ int MapViewState::foodTotalStorage()
 /**
  * Window activation handler.
  */
-void MapViewState::onActivate(bool _b)
+void MapViewState::onActivate(bool /*_b*/)
 {
 	mLeftButtonDown = false;
 }
@@ -321,7 +321,7 @@ void MapViewState::onWindowResized(int w, int h)
 /**
  * Key down event handler.
  */
-void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool /*repeat*/)
 {
 	if (!active()) { return; }
 
@@ -457,7 +457,7 @@ void MapViewState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifie
 /**
  * Mouse Down event handler.
  */
-void MapViewState::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void MapViewState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int /*y*/)
 {
 	if (!active()) { return; }
 
@@ -598,7 +598,7 @@ void MapViewState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int x, int y)
+void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int /*x*/, int /*y*/)
 {
 	if (!active()) { return; }
 
@@ -626,7 +626,7 @@ void MapViewState::onMouseDoubleClick(EventHandler::MouseButton button, int x, i
 /**
 * Mouse Up event handler.
 */
-void MapViewState::onMouseUp(EventHandler::MouseButton button, int x, int y)
+void MapViewState::onMouseUp(EventHandler::MouseButton button, int /*x*/, int /*y*/)
 {
 	if (button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
@@ -638,7 +638,7 @@ void MapViewState::onMouseUp(EventHandler::MouseButton button, int x, int y)
 /**
 * Mouse motion event handler.
 */
-void MapViewState::onMouseMove(int x, int y, int rX, int rY)
+void MapViewState::onMouseMove(int /*x*/, int /*y*/, int /*rX*/, int /*rY*/)
 {
 	if (!active()) { return; }
 
@@ -658,7 +658,7 @@ void MapViewState::onMouseMove(int x, int y, int rX, int rY)
 /**
  * Mouse wheel event handler.
  */
-void MapViewState::onMouseWheel(int x, int y)
+void MapViewState::onMouseWheel(int /*x*/, int y)
 {
 	if (mInsertMode != INSERT_TUBE) { return; }
 

--- a/src/States/MapViewState.cpp
+++ b/src/States/MapViewState.cpp
@@ -808,7 +808,7 @@ void MapViewState::placeRobot()
 			tile->pushMine(nullptr);
 			for (size_t i = 0; i <= static_cast<size_t>(mTileMap->maxDepth()); ++i)
 			{
-				Tile* _t = mTileMap->getTile(mTileMap->tileMouseHoverX(), mTileMap->tileMouseHoverY(), i);
+				Tile* _t = mTileMap->getTile(mTileMap->tileMouseHoverX(), mTileMap->tileMouseHoverY(), static_cast<int>(i));
 
 				// Probably overkill here but if this is ever true there is a serious logic error somewhere.
 				if (!_t->thing() || !_t->thingIsStructure())
@@ -1163,7 +1163,7 @@ void MapViewState::updateRobots()
 			{
 				doAlertMessage(constants::ROBOT_BREAKDOWN_TITLE, string_format(constants::ROBOT_BREAKDOWN_MESSAGE, robot_it->first->name().c_str(), robot_it->second->x(), robot_it->second->y()));
 				Robodozer* _d = dynamic_cast<Robodozer*>(robot_it->first);
-				if (_d) { robot_it->second->index(_d->tileIndex()); }
+				if (_d) { robot_it->second->index(static_cast<int>(_d->tileIndex())); }
 			}
 
 			if (robot_it->second->thing() == robot_it->first)

--- a/src/States/MapViewStateDraw.cpp
+++ b/src/States/MapViewStateDraw.cpp
@@ -67,15 +67,21 @@ extern std::vector<void*> path;
 void MapViewState::drawMiniMap()
 {
 	Renderer& r = Utility<Renderer>::get();
-	r.clipRect(mMiniMapBoundingBox.x(), mMiniMapBoundingBox.y(), mMiniMapBoundingBox.width(), mMiniMapBoundingBox.height());
+	auto miniMapX = static_cast<float>(mMiniMapBoundingBox.x());
+	auto miniMapY = static_cast<float>(mMiniMapBoundingBox.y());
+	float clipX = static_cast<float>(miniMapX);
+	float clipY = static_cast<float>(miniMapY);
+	float clipW = static_cast<float>(mMiniMapBoundingBox.width());
+	float clipH = static_cast<float>(mMiniMapBoundingBox.height());
+	r.clipRect(clipX, clipY, clipW, clipH);
 
-	if (mBtnToggleHeightmap.toggled()) { r.drawImage(mHeightMap, mMiniMapBoundingBox.x(), mMiniMapBoundingBox.y()); }
-	else { r.drawImage(mMapDisplay, mMiniMapBoundingBox.x(), mMiniMapBoundingBox.y()); }
+	if (mBtnToggleHeightmap.toggled()) { r.drawImage(mHeightMap, clipX, clipY); }
+	else { r.drawImage(mMapDisplay, clipX, clipY); }
 
 	if (ccLocationX() != 0 && ccLocationY() != 0)
 	{
-		r.drawSubImage(mUiIcons, ccLocationX() + mMiniMapBoundingBox.x() - 15, ccLocationY() + mMiniMapBoundingBox.y() - 15, 166, 226, 30, 30);
-		r.drawBoxFilled(ccLocationX() + mMiniMapBoundingBox.x() - 1, ccLocationY() + mMiniMapBoundingBox.y() - 1, 3, 3, 255, 255, 255);
+		r.drawSubImage(mUiIcons, ccLocationX() + miniMapX - 15.0f, ccLocationY() + miniMapY - 15.0f, 166, 226, 30, 30);
+		r.drawBoxFilled(ccLocationX() + miniMapX - 1.0f, ccLocationY() + miniMapY - 1.0f, 3.0f, 3.0f, 255, 255, 255);
 	}
 
 	for (auto _tower : Utility<StructureManager>::get().structureList(Structure::CLASS_COMM))
@@ -83,44 +89,46 @@ void MapViewState::drawMiniMap()
 		if (_tower->operational())
 		{
 			Tile* t = Utility<StructureManager>::get().tileFromStructure(_tower);
-			r.drawSubImage(mUiIcons, t->x() + mMiniMapBoundingBox.x() - 10, t->y() + mMiniMapBoundingBox.y() - 10, 146, 236, 20, 20);
+			r.drawSubImage(mUiIcons, t->x() + miniMapX - 10.0f, t->y() + miniMapY - 10.0f, 146.0f, 236.0f, 20.0f, 20.0f);
 		}
 	}
 
-	for (auto _mine : mTileMap->mineLocations())
+	for (auto mine_tile_coords : mTileMap->mineLocations())
 	{
-		Mine* mine = mTileMap->getTile(_mine.x(), _mine.y(), 0)->mine();
+		auto mine_tcX = mine_tile_coords.x();
+		auto mine_tcY = mine_tile_coords.y();
+		Mine* mine = mTileMap->getTile(mine_tcX, mine_tcY, 0)->mine();
 		if (!mine) { break; } // avoids potential race condition where a mine is destroyed during an updated cycle.
 
 		if (!mine->active())
 		{
-			r.drawSubImage(mUiIcons, _mine.x() + mMiniMapBoundingBox.x() - 2, _mine.y() + mMiniMapBoundingBox.y() - 2, 0.0f, 0.0f, 7.0f, 7.0f);
+			r.drawSubImage(mUiIcons, mine_tcX + miniMapX - 2.0f, mine_tcY + miniMapY - 2, 0.0f, 0.0f, 7.0f, 7.0f);
 		}
 		else if (mine->active() && !mine->exhausted())
 		{
-			r.drawSubImage(mUiIcons, _mine.x() + mMiniMapBoundingBox.x() - 2, _mine.y() + mMiniMapBoundingBox.y() - 2, 8.0f, 0.0f, 7.0f, 7.0f);
+			r.drawSubImage(mUiIcons, mine_tcX + miniMapX - 2.0f, mine_tcY + miniMapY - 2.0f, 8.0f, 0.0f, 7.0f, 7.0f);
 		}
 		else if (mine->exhausted())
 		{
-			r.drawSubImage(mUiIcons, _mine.x() + mMiniMapBoundingBox.x() - 2, _mine.y() + mMiniMapBoundingBox.y() - 2, 16.0f, 0.0f, 7.0f, 7.0f);
+			r.drawSubImage(mUiIcons, mine_tcX + miniMapX - 2.0f, mine_tcY + miniMapY - 2.0f, 16.0f, 0.0f, 7.0f, 7.0f);
 		}
 
 	}
 
 	for (auto _tile : path)
 	{
-		r.drawPoint(static_cast<Tile*>(_tile)->x() + mMiniMapBoundingBox.x(), static_cast<Tile*>(_tile)->y() + mMiniMapBoundingBox.y(), NAS2D::Color::Magenta);
+		r.drawPoint(static_cast<Tile*>(_tile)->x() + miniMapX, static_cast<Tile*>(_tile)->y() + miniMapY, NAS2D::Color::Magenta);
 	}
 
 	for (auto _robot : mRobotList)
 	{
-		r.drawPoint(_robot.second->x() + mMiniMapBoundingBox.x(), _robot.second->y() + mMiniMapBoundingBox.y(), 0, 255, 255);
+		r.drawPoint(_robot.second->x() + miniMapX, _robot.second->y() + miniMapY, 0, 255, 255);
 	}
 
 	const Point_2d& _pt = mTileMap->mapViewLocation();
-
-	r.drawBox(mMiniMapBoundingBox.x() + _pt.x() + 1, mMiniMapBoundingBox.y() + _pt.y() + 1, mTileMap->edgeLength(), mTileMap->edgeLength(), 0, 0, 0, 180);
-	r.drawBox(mMiniMapBoundingBox.x() + _pt.x(), mMiniMapBoundingBox.y() + _pt.y(), mTileMap->edgeLength(), mTileMap->edgeLength(), 255, 255, 255);
+	float edge_length = static_cast<float>(mTileMap->edgeLength());
+	r.drawBox(miniMapX + _pt.x() + 1, miniMapY + _pt.y() + 1, edge_length, edge_length, 0, 0, 0, 180);
+	r.drawBox(miniMapX + _pt.x(), miniMapY + _pt.y(), edge_length, edge_length, 255, 255, 255);
 
 	r.clipRectClear();
 }
@@ -133,56 +141,57 @@ void MapViewState::drawResourceInfo()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawBoxFilled(0, 0, r.width(), constants::RESOURCE_ICON_SIZE + 4, 39, 39, 39);
-	r.drawBox(0, 0, r.width(), constants::RESOURCE_ICON_SIZE + 4, 21, 21, 21);
-	r.drawLine(1, 0, r.width() - 2, 0, 56, 56, 56);
+	r.drawBoxFilled(0.0f, 0.0f, r.width(), constants::RESOURCE_ICON_SIZE + 4, 39, 39, 39);
+	r.drawBox(0.0f, 0.0f, r.width(), constants::RESOURCE_ICON_SIZE + 4.0f, 21, 21, 21);
+	r.drawLine(1.0f, 0.0f, r.width() - 2.0f, 0.0f, 56, 56, 56);
 
 	// Resources
-	int x = constants::MARGIN_TIGHT + 12;
-	int y = constants::MARGIN_TIGHT;
+	float x = constants::MARGIN_TIGHT + 12.0f;
+	float y = constants::MARGIN_TIGHT;
 
-	int textY = 3;
-	int offsetX = constants::RESOURCE_ICON_SIZE + 40;
-	int margin = constants::RESOURCE_ICON_SIZE + constants::MARGIN;
+	float textY = 3.0f;
+	float offsetX = constants::RESOURCE_ICON_SIZE + 40.0f;
+	float margin = constants::RESOURCE_ICON_SIZE + constants::MARGIN;
 
-	r.drawSubImage(mUiIcons, 2, 7, mPinResourcePanel ? 8 : 0, 72, 8, 8);
-	r.drawSubImage(mUiIcons, 675, 7, mPinPopulationPanel ? 8 : 0, 72, 8, 8);
+	r.drawSubImage(mUiIcons, 2.0f, 7.0f, mPinResourcePanel ? 8.0f : 0.0f, 72.0f, 8.0f, 8.0f);
+	r.drawSubImage(mUiIcons, 675.0f, 7.0f, mPinPopulationPanel ? 8.0f : 0.0f, 72.0f, 8.0f, 8.0f);
 
 	updateGlowTimer();
 
 	// Common Metals
 	r.drawSubImage(mUiIcons, x, y , 64, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.commonMetals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMetals()), x + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	auto glowStepAsUint8 = static_cast<uint8_t>(GLOW_STEP);
+	if (mPlayerResources.commonMetals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMetals()), x + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMetals()), x + margin, textY, 255, 255, 255); }
 
 	// Rare Metals
 	r.drawSubImage(mUiIcons, x + offsetX, y, 80, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.rareMetals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMetals()), (x + offsetX) + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (mPlayerResources.rareMetals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMetals()), (x + offsetX) + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMetals()), (x + offsetX) + margin, textY, 255, 255, 255); }
 
 	// Common Minerals
 	r.drawSubImage(mUiIcons, (x + offsetX) * 2, y, 96, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.commonMinerals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMinerals()), (x + offsetX) * 2 + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (mPlayerResources.commonMinerals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMinerals()), (x + offsetX) * 2 + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.commonMinerals()), (x + offsetX) * 2 + margin, textY, 255, 255, 255); }
 
 	// Rare Minerals
 	r.drawSubImage(mUiIcons, (x + offsetX) * 3, y, 112, 16, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.rareMinerals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMinerals()), (x + offsetX) * 3 + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (mPlayerResources.rareMinerals() <= 10) { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMinerals()), (x + offsetX) * 3 + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i", mPlayerResources.rareMinerals()), (x + offsetX) * 3 + margin, textY, 255, 255, 255); }
 
 	// Storage Capacity
 	r.drawSubImage(mUiIcons, (x + offsetX) * 4, y, 96, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.capacity() - mPlayerResources.currentLevel() <= 100) { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.currentLevel(), mPlayerResources.capacity()), (x + offsetX) * 4 + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (mPlayerResources.capacity() - mPlayerResources.currentLevel() <= 100) { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.currentLevel(), mPlayerResources.capacity()), (x + offsetX) * 4 + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.currentLevel(), mPlayerResources.capacity()), (x + offsetX) * 4 + margin, textY, 255, 255, 255); }
 
 	// Food
 	r.drawSubImage(mUiIcons, (x + offsetX) * 6, y, 64, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (foodInStorage() <= 10) { r.drawText(*MAIN_FONT, string_format("%i/%i", foodInStorage(), foodTotalStorage()), (x + offsetX) * 6 + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (foodInStorage() <= 10) { r.drawText(*MAIN_FONT, string_format("%i/%i", foodInStorage(), foodTotalStorage()), (x + offsetX) * 6 + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i/%i", foodInStorage(), foodTotalStorage()), (x + offsetX) * 6 + margin, textY, 255, 255, 255); }
 
 	// Energy
 	r.drawSubImage(mUiIcons, (x + offsetX) * 8, y, 80, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
-	if (mPlayerResources.energy() <= 5) { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.energy(), Utility<StructureManager>::get().totalEnergyProduction()), (x + offsetX) * 8 + margin, textY, 255, GLOW_STEP, GLOW_STEP); }
+	if (mPlayerResources.energy() <= 5) { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.energy(), Utility<StructureManager>::get().totalEnergyProduction()), (x + offsetX) * 8 + margin, textY, 255, glowStepAsUint8, glowStepAsUint8); }
 	else { r.drawText(*MAIN_FONT, string_format("%i/%i", mPlayerResources.energy(), Utility<StructureManager>::get().totalEnergyProduction()), (x + offsetX) * 8 + margin, textY, 255, 255, 255); }
 
 	// Population / Morale
@@ -190,18 +199,18 @@ void MapViewState::drawResourceInfo()
 	else if (mCurrentMorale < mPreviousMorale) { r.drawSubImage(mUiIcons, (x + offsetX) * 10 - 17, y, 0, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
 	else { r.drawSubImage(mUiIcons, (x + offsetX) * 10 - 17, y, 32, 48, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
 
-	r.drawSubImage(mUiIcons, (x + offsetX) * 10, y, 176 + (std::clamp(mCurrentMorale, 1, 999) / 200) * constants::RESOURCE_ICON_SIZE, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
+	r.drawSubImage(mUiIcons, (x + offsetX) * 10.0f, y, 176.0f + (std::clamp(mCurrentMorale, 1, 999) / 200) * constants::RESOURCE_ICON_SIZE, 0.0f, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	r.drawText(*MAIN_FONT, string_format("%i", mPopulation.size()), (x + offsetX) * 10 + margin, textY, 255, 255, 255);
 
 	if (mPinPopulationPanel	|| isPointInRect(MOUSE_COORDS.x(), MOUSE_COORDS.y(), 675, 1, 75, 19)) { mPopulationPanel.update(); }
-	if (mPinResourcePanel	|| isPointInRect(MOUSE_COORDS.x(), MOUSE_COORDS.y(), 0, 1, mResourceBreakdownPanel.width(), 19)) { mResourceBreakdownPanel.update(); }
+	if (mPinResourcePanel	|| isPointInRect(MOUSE_COORDS.x(), MOUSE_COORDS.y(), 0, 1, static_cast<int>(mResourceBreakdownPanel.width()), 19)) { mResourceBreakdownPanel.update(); }
 
 	// Turns
 	r.drawSubImage(mUiIcons, r.width() - 80, y, 128, 0, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE);
 	r.drawText(*MAIN_FONT, string_format("%i", mTurnCount), r.width() - 80 + margin, textY, 255, 255, 255);
 
-	if (isPointInRect(MOUSE_COORDS, MENU_ICON)) { r.drawSubImage(mUiIcons, MENU_ICON.x() + constants::MARGIN_TIGHT, MENU_ICON.y() + constants::MARGIN_TIGHT, 144, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
-	else { r.drawSubImage(mUiIcons, MENU_ICON.x() + constants::MARGIN_TIGHT, MENU_ICON.y() + constants::MARGIN_TIGHT, 128, 32, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
+	if (isPointInRect(MOUSE_COORDS, MENU_ICON)) { r.drawSubImage(mUiIcons, static_cast<float>(MENU_ICON.x()) + constants::MARGIN_TIGHT, static_cast<float>(MENU_ICON.y()) + constants::MARGIN_TIGHT, 144.0f, 32.0f, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
+	else { r.drawSubImage(mUiIcons, static_cast<float>(MENU_ICON.x()) + constants::MARGIN_TIGHT, static_cast<float>(MENU_ICON.y()) + constants::MARGIN_TIGHT, 128.0f, 32.0f, constants::RESOURCE_ICON_SIZE, constants::RESOURCE_ICON_SIZE); }
 }
 
 
@@ -217,26 +226,29 @@ void MapViewState::drawRobotInfo()
 
 	// Robots
 	// Start from the bottom - The bottom UI Height - Icons Height - 8 (1 offset to avoid the last to be glued with at the border)
-	int y = (int)r.height() - constants::BOTTOM_UI_HEIGHT - 25 - 8;
-	int textY = y + 7;	// Same position + 10 to center the text with the graphics
-	int margin = 30;	// Margin of 28 px from the graphics to the text
-	int x = 0, offsetX = 1;	// Start a the left side of the screen + an offset of 1 to detatch from the border
+	float y = r.height() - constants::BOTTOM_UI_HEIGHT - 25.0f - 8.0f;
+	float textY = y + 7.0f;	// Same position + 10 to center the text with the graphics
+	float margin = 30.0f;	// Margin of 28 px from the graphics to the text
+	float x = 0.0f;
+	float offsetX = 1.0f;	// Start a the left side of the screen + an offset of 1 to detatch from the border
 	
 	// Miner (last one)
-	r.drawSubImage(mUiIcons, (x + offsetX) * 8, y, 231, 18, 25, 25);
+	r.drawSubImage(mUiIcons, (x + offsetX) * 8.0f, y, 231.0f, 18.0f, 25.0f, 25.0f);
 	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.getAvailableCount(ROBOT_MINER), mRobotPool.miners().size()), (x + offsetX) * 8 + margin, textY, 255, 255, 255);
 	// Dozer (Midle one)
 	textY -= 25; y -= 25;
-	r.drawSubImage(mUiIcons, (x + offsetX) * 8, y, 206, 18, 25, 25);
-	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.getAvailableCount(ROBOT_DOZER), mRobotPool.dozers().size()), (x + offsetX) * 8 + margin, textY, 255, 255, 255);
+	r.drawSubImage(mUiIcons, (x + offsetX) * 8.0f, y, 206.0f, 18.0f, 25.0f, 25.0f);
+	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.getAvailableCount(ROBOT_DOZER), mRobotPool.dozers().size()), (x + offsetX) * 8.0f + margin, textY, 255, 255, 255);
 	// Digger (First one)
-	textY -= 25; y -= 25;
-	r.drawSubImage(mUiIcons, (x + offsetX) * 8, y, 181, 18, 25, 25);
-	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.getAvailableCount(ROBOT_DIGGER), mRobotPool.diggers().size()), (x + offsetX) * 8 + margin, textY, 255, 255, 255);
+	textY -= 25.0f;
+	y -= 25.0f;
+	r.drawSubImage(mUiIcons, (x + offsetX) * 8.0f, y, 181.0f, 18.0f, 25.0f, 25.0f);
+	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.getAvailableCount(ROBOT_DIGGER), mRobotPool.diggers().size()), (x + offsetX) * 8.0f + margin, textY, 255, 255, 255);
 	// robot control summary
-	textY -= 25; y -= 25;
-	r.drawSubImage(mUiIcons, (x + offsetX) * 8, y, 231, 43, 25, 25);
-	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.currentControlCount(), mRobotPool.robotControlMax()), (x + offsetX) * 8 + margin, textY, 255, 255, 255);
+	textY -= 25.0f;
+	y -= 25.0f;
+	r.drawSubImage(mUiIcons, (x + offsetX) * 8.0f, y, 231.0f, 43.0f, 25.0f, 25.0f);
+	r.drawText(*MAIN_FONT, string_format("%i/%i", mRobotPool.currentControlCount(), mRobotPool.robotControlMax()), (x + offsetX) * 8.0f + margin, textY, 255, 255, 255);
 }
 
 
@@ -247,67 +259,79 @@ void MapViewState::drawNavInfo()
 {
 	Renderer& r = Utility<Renderer>::get();
 
+	float move_icon_x = static_cast<float>(MOVE_DOWN_ICON.x());
+	float move_icon_y = static_cast<float>(MOVE_DOWN_ICON.y());
 	// Up / Down
 	if (isPointInRect(MOUSE_COORDS, MOVE_DOWN_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y(), 64, 128, 32, 32, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 64.0f, 128.0f, 32.0f, 32.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_DOWN_ICON.x(), MOVE_DOWN_ICON.y(), 64, 128, 32, 32);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 64.0f, 128.0f, 32.0f, 32.0f);
 	}
 
+    move_icon_x = static_cast<float>(MOVE_UP_ICON.x());
+    move_icon_y = static_cast<float>(MOVE_UP_ICON.y());
 	if (isPointInRect(MOUSE_COORDS, MOVE_UP_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_UP_ICON.x(), MOVE_UP_ICON.y(), 96, 128, 32, 32, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 96.0f, 128.0f, 32.0f, 32.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_UP_ICON.x(), MOVE_UP_ICON.y(), 96, 128, 32, 32);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 96.0f, 128.0f, 32.0f, 32.0f);
 	}
 
+    move_icon_x = static_cast<float>(MOVE_EAST_ICON.x());
+    move_icon_y = static_cast<float>(MOVE_EAST_ICON.y());
 	// East / West / North / South
 	if (isPointInRect(MOUSE_COORDS, MOVE_EAST_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_EAST_ICON.x(), MOVE_EAST_ICON.y(), 32, 128, 32, 16, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 32.0f, 128.0f, 32.0f, 16.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_EAST_ICON.x(), MOVE_EAST_ICON.y(), 32, 128, 32, 16);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 32.0f, 128.0f, 32.0f, 16.0f);
 	}
 
+    move_icon_x = static_cast<float>(MOVE_WEST_ICON.x());
+    move_icon_y = static_cast<float>(MOVE_WEST_ICON.y());
 	if (isPointInRect(MOUSE_COORDS, MOVE_WEST_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_WEST_ICON.x(), MOVE_WEST_ICON.y(), 32, 144, 32, 16, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 32.0f, 144.0f, 32.0f, 16.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_WEST_ICON.x(), MOVE_WEST_ICON.y(), 32, 144, 32, 16);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 32.0f, 144.0f, 32.0f, 16.0f);
 	}
 
+    move_icon_x = static_cast<float>(MOVE_NORTH_ICON.x());
+    move_icon_y = static_cast<float>(MOVE_NORTH_ICON.y());
 	if (isPointInRect(MOUSE_COORDS, MOVE_NORTH_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_NORTH_ICON.x(), MOVE_NORTH_ICON.y(), 0, 128, 32, 16, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 0.0f, 128.0f, 32.0f, 16.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_NORTH_ICON.x(), MOVE_NORTH_ICON.y(), 0, 128, 32, 16);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 0.0f, 128.0f, 32.0f, 16.0f);
 	}
 
+    move_icon_x = static_cast<float>(MOVE_SOUTH_ICON.x());
+    move_icon_y = static_cast<float>(MOVE_SOUTH_ICON.y());
 	if (isPointInRect(MOUSE_COORDS, MOVE_SOUTH_ICON))
 	{
-		r.drawSubImage(mUiIcons, MOVE_SOUTH_ICON.x(), MOVE_SOUTH_ICON.y(), 0, 144, 32, 16, 255, 0, 0, 255);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 0.0f, 144.0f, 32.0f, 16.0f, 255, 0, 0, 255);
 	}
 	else
 	{
-		r.drawSubImage(mUiIcons, MOVE_SOUTH_ICON.x(), MOVE_SOUTH_ICON.y(), 0, 144, 32, 16);
+		r.drawSubImage(mUiIcons, move_icon_x, move_icon_y, 0.0f, 144.0f, 32.0f, 16.0f);
 	}
 
 
 	// display the levels "bar"
 	int iWidth = MAIN_FONT->width("IX");								// set steps character patern width
-	int iPosX = r.width() - 5;											// set start position from right border
-	int iPosY = mMiniMapBoundingBox.y() - MAIN_FONT->height() - 30;	// set vertical position
+	float iPosX = r.width() - 5.0f;											// set start position from right border
+	float iPosY = mMiniMapBoundingBox.y() - MAIN_FONT->height() - 30.0f;	// set vertical position
 	
 	for (int i = mTileMap->maxDepth(); i >= 0; i--)
 	{

--- a/src/States/MapViewStateEvent.cpp
+++ b/src/States/MapViewStateEvent.cpp
@@ -182,7 +182,7 @@ void MapViewState::deploySeedLander(int x, int y)
 /**
  * Called whenever a RoboDozer completes its task.
  */
-void MapViewState::dozerTaskFinished(Robot* _r)
+void MapViewState::dozerTaskFinished(Robot* /*_r*/)
 {
 	checkRobotSelectionInterface(constants::ROBODOZER, constants::ROBODOZER_SHEET_ID, ROBOT_DOZER);
 }

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -265,7 +265,7 @@ bool landingSiteSuitable(TileMap* tilemap, int x, int y)
 /**
  * Document me!
  */
-void deleteRobotsInRCC(Robot* r, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* tile)
+void deleteRobotsInRCC(Robot* r, RobotCommand* rcc, RobotPool& rp, RobotTileTable& rtt, Tile* /*tile*/)
 {
 	if (rcc->commandedByThis(r))
 	{

--- a/src/States/MapViewStateHelper.cpp
+++ b/src/States/MapViewStateHelper.cpp
@@ -187,8 +187,9 @@ bool validLanderSite(Tile* t)
 	}
 
 	// bleh, direct copy from Tile::distanceTo()
-	int _x = t->x() - ccLocationX(), _y = t->y() - ccLocationY();
-	float _dist = sqrt((_x * _x) + (_y * _y));
+	int _x = t->x() - ccLocationX();
+	int _y = t->y() - ccLocationY();
+	float _dist = std::sqrt(static_cast<float>(_x * _x) + _y * _y);
 	if (_dist > constants::LANDER_COM_RANGE)
 	{
 		doAlertMessage(constants::ALERT_LANDER_LOCATION, constants::ALERT_LANDER_COMM_RANGE);
@@ -376,7 +377,7 @@ Warehouse* getAvailableWarehouse(ProductType _pt, size_t _ct)
 	for (auto _st : Utility<StructureManager>::get().structureList(Structure::CLASS_WAREHOUSE))
 	{
 		Warehouse* _wh = static_cast<Warehouse*>(_st);
-		if (_wh->products().canStore(_pt, _ct))
+		if (_wh->products().canStore(_pt, static_cast<int>(_ct)))
 		{
 			return _wh;
 		}

--- a/src/States/MapViewStateTurn.cpp
+++ b/src/States/MapViewStateTurn.cpp
@@ -318,11 +318,6 @@ void MapViewState::nextTurn()
 	mMineOperationsWindow.updateCounts();
 	mStructureInspector.check();
 
-
-	float totalCost = 0;
-	int result = pather->Solve(mTileMap->getTile(299, 149), mTileMap->getTile(10, 10), &path, &totalCost);
-
-
 	// Check for Game Over conditions
 	if (mPopulation.size() < 1 && mLandersColonist == 0)
 	{

--- a/src/States/MapViewStateUi.cpp
+++ b/src/States/MapViewStateUi.cpp
@@ -420,7 +420,7 @@ void MapViewState::structuresSelectionChanged(const IconGrid::IconGridItem* _ite
 /**
  * Handler for the Tubes Pallette dialog.
  */
-void MapViewState::connectionsSelectionChanged(const IconGrid::IconGridItem* _item)
+void MapViewState::connectionsSelectionChanged(const IconGrid::IconGridItem* /*_item*/)
 {
 	mRobots.clearSelection();
 	mStructures.clearSelection();

--- a/src/States/MapViewStateUi.cpp
+++ b/src/States/MapViewStateUi.cpp
@@ -77,13 +77,13 @@ void MapViewState::initUi()
 	mDiggerDirection.directionSelected().connect(this, &MapViewState::diggerSelectionDialog);
 	mDiggerDirection.hide();
 
-	mTileInspector.position(static_cast<int>(r.center_x() - mTileInspector.width() / 2), static_cast<int>(r.height() / 2 - 175));
+	mTileInspector.position(r.center_x() - mTileInspector.width() / 2.0f, r.height() / 2.0f - 175.0f);
 	mTileInspector.hide();
 
-	mStructureInspector.position(static_cast<int>(r.center_x() - mStructureInspector.width() / 2), static_cast<int>(r.height() / 2 - 175));
+	mStructureInspector.position(r.center_x() - mStructureInspector.width() / 2.0f, r.height() / 2.0f - 175.0f);
 	mStructureInspector.hide();
 
-	mFactoryProduction.position(static_cast<int>(r.center_x() - mFactoryProduction.width() / 2), 175);
+	mFactoryProduction.position(r.center_x() - mFactoryProduction.width() / 2.0f, 175.0f);
 	mFactoryProduction.hide();
 
 	mFileIoDialog.setMode(FileIo::FILE_SAVE);
@@ -91,12 +91,12 @@ void MapViewState::initUi()
 	mFileIoDialog.anchored(true);
 	mFileIoDialog.hide();
 
-	mPopulationPanel.position(675, constants::RESOURCE_ICON_SIZE + 4 + constants::MARGIN_TIGHT);
+	mPopulationPanel.position(675.0f, constants::RESOURCE_ICON_SIZE + 4.0f + constants::MARGIN_TIGHT);
 	mPopulationPanel.population(&mPopulation);
 	mPopulationPanel.morale(&mCurrentMorale);
 	mPopulationPanel.old_morale(&mPreviousMorale);
 
-	mResourceBreakdownPanel.position(0, 22);
+	mResourceBreakdownPanel.position(0.0f, 22.0f);
 	mResourceBreakdownPanel.playerResources(&mPlayerResources);
 
 	mGameOverDialog.returnToMainMenu().connect(this, &MapViewState::btnGameOverClicked);
@@ -140,16 +140,16 @@ void MapViewState::initUi()
 
 	// Menus
 	mRobots.sheetPath("ui/robots.png");
-	mRobots.position(static_cast<float>(mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52), static_cast<float>(BOTTOM_UI_AREA.y() + MARGIN));
-	mRobots.size(52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2);
+	mRobots.position(static_cast<float>(mBtnTurns.positionX() - constants::MARGIN_TIGHT - 52.0f), static_cast<float>(BOTTOM_UI_AREA.y() + MARGIN));
+	mRobots.size(52.0f, BOTTOM_UI_HEIGHT - constants::MARGIN * 2.0f);
 	mRobots.iconSize(46);
 	mRobots.iconMargin(constants::MARGIN_TIGHT);
 	mRobots.showTooltip(true);
 	mRobots.selectionChanged().connect(this, &MapViewState::robotsSelectionChanged);
 
 	mConnections.sheetPath("ui/structures.png");
-	mConnections.position(static_cast<float>(mRobots.positionX() - constants::MARGIN_TIGHT - 52), static_cast<float>(BOTTOM_UI_AREA.y() + MARGIN));
-	mConnections.size(52, BOTTOM_UI_HEIGHT - constants::MARGIN * 2);
+	mConnections.position(static_cast<float>(mRobots.positionX() - constants::MARGIN_TIGHT - 52.0f), static_cast<float>(BOTTOM_UI_AREA.y() + MARGIN));
+	mConnections.size(52.0f, BOTTOM_UI_HEIGHT - constants::MARGIN * 2.0f);
 	mConnections.iconSize(46);
 	mConnections.iconMargin(constants::MARGIN_TIGHT);
 	mConnections.selectionChanged().connect(this, &MapViewState::connectionsSelectionChanged);
@@ -157,7 +157,7 @@ void MapViewState::initUi()
 
 	mStructures.sheetPath("ui/structures.png");
 	mStructures.position(static_cast<float>(constants::MARGIN), static_cast<float>(BOTTOM_UI_AREA.y() + MARGIN));
-	mStructures.size(mConnections.positionX() -  constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2);
+	mStructures.size(mConnections.positionX() -  constants::MARGIN - constants::MARGIN_TIGHT, BOTTOM_UI_HEIGHT - constants::MARGIN * 2.0f);
 	mStructures.iconSize(46);
 	mStructures.iconMargin(constants::MARGIN_TIGHT);
 	mStructures.showTooltip(true);
@@ -208,15 +208,15 @@ void MapViewState::setupUiPositions(int w, int h)
 	mStructures.iconMargin(constants::MARGIN_TIGHT);
 
 	// Anchored window positions
-	mFileIoDialog.position(centerWindowWidth(mFileIoDialog.width()), 50);
-	mGameOverDialog.position(centerWindowWidth(mGameOverDialog.width()), centerWindowHeight(mGameOverDialog.height()) - 100);
-	mAnnouncement.position(centerWindowWidth(mAnnouncement.width()), centerWindowHeight(mAnnouncement.height()) - 100);
-	mGameOptionsDialog.position(centerWindowWidth(mGameOptionsDialog.width()), centerWindowHeight(mGameOptionsDialog.height()) - 100);
+	mFileIoDialog.position(static_cast<float>(centerWindowWidth(mFileIoDialog.width())), 50.0f);
+	mGameOverDialog.position(static_cast<float>(centerWindowWidth(mGameOverDialog.width())), centerWindowHeight(mGameOverDialog.height()) - 100.0f);
+	mAnnouncement.position(static_cast<float>(centerWindowWidth(mAnnouncement.width())), centerWindowHeight(mAnnouncement.height()) - 100.0f);
+	mGameOptionsDialog.position(static_cast<float>(centerWindowWidth(mGameOptionsDialog.width())), centerWindowHeight(mGameOptionsDialog.height()) - 100.0f);
 
-	mDiggerDirection.position(centerWindowWidth(mDiggerDirection.width()), static_cast<int>(h / 2) - 125);
+	mDiggerDirection.position(static_cast<float>(centerWindowWidth(mDiggerDirection.width())), static_cast<int>(h / 2.0f) - 125.0f);
 
-	mWarehouseInspector.position(centerWindowWidth(mWarehouseInspector.width()), centerWindowHeight(mWarehouseInspector.height()) - 100);
-	mMineOperationsWindow.position(centerWindowWidth(mMineOperationsWindow.width()), centerWindowHeight(mMineOperationsWindow.height()) - 100);
+	mWarehouseInspector.position(static_cast<float>(centerWindowWidth(mWarehouseInspector.width())), centerWindowHeight(mWarehouseInspector.height()) - 100.0f);
+	mMineOperationsWindow.position(static_cast<float>(centerWindowWidth(mMineOperationsWindow.width())), centerWindowHeight(mMineOperationsWindow.height()) - 100.0f);
 
 	/**
 	 * \note	We are not setting the tile inspector window's position here because it's something that can be

--- a/src/States/Planet.cpp
+++ b/src/States/Planet.cpp
@@ -56,7 +56,7 @@ bool Planet::pointInArea(int x, int y)
 }
 
 
-void Planet::onMouseMove(int x, int y, int rX, int rY)
+void Planet::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 {
 	bool inArea = pointInArea(x, y);
 	if (inArea != mMouseInArea)

--- a/src/States/PlanetSelectState.cpp
+++ b/src/States/PlanetSelectState.cpp
@@ -224,7 +224,7 @@ State* PlanetSelectState::update()
 }
 
 
-void PlanetSelectState::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void PlanetSelectState::onMouseDown(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
 {
 	for (size_t i = 0; i < mPlanets.size(); ++i)
 	{
@@ -240,7 +240,7 @@ void PlanetSelectState::onMouseDown(EventHandler::MouseButton button, int x, int
 }
 
 
-void PlanetSelectState::onMouseMove(int x, int y, int rX, int rY)
+void PlanetSelectState::onMouseMove(int x, int y, int /*rX*/, int /*rY*/)
 {
 	mMousePosition = {x, y};
 }

--- a/src/States/PlanetSelectState.cpp
+++ b/src/States/PlanetSelectState.cpp
@@ -36,8 +36,14 @@ public:
 			mTimer.reset();
 		}
 
-		r.drawSubImageRotated(mSheet, x, y, (mFrame % 8) * 128, (mFrame / 8) * 128, 128, 128, 270.0f);
-		//r.drawSubImage(mSheet, x, y, (mFrame % 8) * 128, (mFrame / 8) * 128, 128, 128);
+		auto rasterX = static_cast<float>(x);
+		auto rasterY = static_cast<float>(y);
+		auto posX = static_cast<float>((mFrame % 8u) * 128.0f);
+		auto posY = static_cast<float>((mFrame / 8u) * 128.0f);
+		auto width = 128.0f;
+		auto height = 128.0f;
+		auto orientationDegrees = 270.0f;
+		r.drawSubImageRotated(mSheet, rasterX, rasterY, posX, posY, width, height, orientationDegrees);
 	}
 
 private:
@@ -275,8 +281,8 @@ void PlanetSelectState::onWindowResized(int w, int h)
 	mPlanets[1]->position(w / 2 - 64, h / 2 - 64);
 	mPlanets[2]->position(((w / 4) * 3) - 64, h / 2 - 64);
 
-	mQuit.position(w - 105, 30);
-	mPlanetDescription.position((w / 2) - 275, h - 225);
+	mQuit.position(w - 105.0f, 30.0f);
+	mPlanetDescription.position((w / 2.0f) - 275.0f, h - 225.0f);
 }
 
 

--- a/src/States/SplashState.cpp
+++ b/src/States/SplashState.cpp
@@ -167,13 +167,13 @@ State* SplashState::update()
 }
 
 
-void SplashState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void SplashState::onKeyDown(EventHandler::KeyCode /*key*/, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	skipSplash();
 }
 
 
-void SplashState::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void SplashState::onMouseDown(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
 {
 	skipSplash();
 }

--- a/src/States/SplashState.cpp
+++ b/src/States/SplashState.cpp
@@ -144,7 +144,7 @@ State* SplashState::update()
 		BYLINE_ALPHA += tick * BYLINE_ALPHA_FADE_STEP;
 		BYLINE_ALPHA = std::clamp(BYLINE_ALPHA, -3000.0f, 255.0f);
 
-		if(BYLINE_ALPHA > 0.0f) { r.drawImage(mByline, r.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), r.center_y() + 25, BYLINE_SCALE, 255, 255, 255, (int)BYLINE_ALPHA); }
+		if(BYLINE_ALPHA > 0.0f) { r.drawImage(mByline, r.center_x() - ((mByline.width() * BYLINE_SCALE) / 2), r.center_y() + 25, BYLINE_SCALE, 255u, 255u, 255u, static_cast<uint8_t>(BYLINE_ALPHA)); }
 	}
 	
 	if (r.isFading()) { return this; }

--- a/src/StructureManager.cpp
+++ b/src/StructureManager.cpp
@@ -308,7 +308,7 @@ int StructureManager::count() const
 	int count = 0;
 	for (auto it = mStructureLists.begin(); it != mStructureLists.end(); ++it)
 	{
-		count += it->second.size();
+		count += static_cast<int>(it->second.size());
 	}
 
 	return count;

--- a/src/StructureManager.cpp
+++ b/src/StructureManager.cpp
@@ -106,7 +106,7 @@ void StructureManager::update(ResourcePool& _r, PopulationPool& _p)
 /**
  *
  */
-void StructureManager::updateEnergyProduction(ResourcePool& _r, PopulationPool& _p)
+void StructureManager::updateEnergyProduction(ResourcePool& _r, PopulationPool& /*_p*/)
 {
 	mTotalEnergyOutput = 0;
 

--- a/src/Things/Structures/Structure.h
+++ b/src/Things/Structures/Structure.h
@@ -93,7 +93,7 @@ public:
 	ResourcePool& storage() { return mStoragePool; }
 	ResourcePool& production() { return mProductionPool; }
 
-	virtual void input(ResourcePool& _resourcePool) {}
+	virtual void input(ResourcePool& /*_resourcePool*/) { /* DO NOTHING */ }
 	bool enoughResourcesAvailable(ResourcePool& r);
 
 	const PopulationRequirements& populationRequirements() const { return mPopulationRequirements; }

--- a/src/UI/Core/Button.cpp
+++ b/src/UI/Core/Button.cpp
@@ -146,7 +146,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void Button::onMouseMotion(int x, int y, int dX, int dY)
+void Button::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
 	mMouseHover = pointInRect_f(x, y, rect());
 }

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -115,7 +115,6 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-//TODO: Implement in terms of internal ListBox.
 void ComboBox::onMouseWheel(int /*x*/, int /*y*/)
 {
 

--- a/src/UI/Core/ComboBox.cpp
+++ b/src/UI/Core/ComboBox.cpp
@@ -57,7 +57,7 @@ void ComboBox::init()
 /**
  * Resized event handler.
  */
-void ComboBox::resizedHandler(Control* c)
+void ComboBox::resizedHandler(Control* /*c*/)
 {
 	if (height() < 20) { height(20); } // enforce minimum height;
 	if (width() < 50) { width(50); } // enforce mininum width;
@@ -115,7 +115,8 @@ void ComboBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void ComboBox::onMouseWheel(int x, int y)
+//TODO: Implement in terms of internal ListBox.
+void ComboBox::onMouseWheel(int /*x*/, int /*y*/)
 {
 
 }

--- a/src/UI/Core/Control.h
+++ b/src/UI/Core/Control.h
@@ -76,7 +76,7 @@ protected:
 	 */
 	virtual void positionChanged(float dX, float dY) { mPositionChanged(dX, dY); }
 
-	virtual void visibilityChanged(bool visible) {}
+	virtual void visibilityChanged(bool /*visible*/) { /* DO NOTHING */ }
 
 	virtual void enabledChanged() {};
 

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -183,7 +183,7 @@ void ListBox::setSelectionByName(const std::string& item)
 {
 	for (size_t i = 0; i < mItems.size(); i++)
 	{
-		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = i; return; }
+		if (toLowercase(mItems[i].Text) == toLowercase(item)) { mCurrentSelection = static_cast<int>(i); return; }
 	}
 }
 

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -69,7 +69,7 @@ void ListBox::onSizeChanged()
 }
 
 
-void ListBox::visibilityChanged(bool visible)
+void ListBox::visibilityChanged(bool /*visible*/)
 {
 	_updateItemDisplay();
 }
@@ -198,8 +198,8 @@ void ListBox::dropAllItems()
 	_updateItemDisplay();
 }
 
-
-void ListBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
+//TODO: Intended to only react if LMB?
+void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
@@ -223,7 +223,7 @@ void ListBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void ListBox::onMouseMove(int x, int y, int relX, int relY)
+void ListBox::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
@@ -259,7 +259,7 @@ void ListBox::onMouseMove(int x, int y, int relX, int relY)
 /**
  * \todo	Make the scroll amount configurable.
  */
-void ListBox::onMouseWheel(int x, int y)
+void ListBox::onMouseWheel(int /*x*/, int y)
 {
 	if (empty() || !visible()) { return; }
 

--- a/src/UI/Core/ListBox.cpp
+++ b/src/UI/Core/ListBox.cpp
@@ -198,7 +198,6 @@ void ListBox::dropAllItems()
 	_updateItemDisplay();
 }
 
-//TODO: Intended to only react if LMB?
 void ListBox::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	// Ignore if menu is empty or invisible

--- a/src/UI/Core/ListBoxBase.cpp
+++ b/src/UI/Core/ListBoxBase.cpp
@@ -138,7 +138,7 @@ void ListBoxBase::onMouseDown(EventHandler::MouseButton button, int x, int y)
 /**
  * Mouse Motion event handler.
  */
-void ListBoxBase::onMouseMove(int x, int y, int relX, int relY)
+void ListBoxBase::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	if (!visible() || empty()) { return; }
 
@@ -177,7 +177,7 @@ void ListBoxBase::onMouseMove(int x, int y, int relX, int relY)
  * 
  * \todo	Make the scroll step configurable. Legacy from the ListBox.
  */
-void ListBoxBase::onMouseWheel(int x, int y)
+void ListBoxBase::onMouseWheel(int /*x*/, int y)
 {
 	if (!visible()) { return; }
 	if (!isPointInRect(mMousePosition, rect())) { return; }

--- a/src/UI/Core/Slider.cpp
+++ b/src/UI/Core/Slider.cpp
@@ -258,7 +258,7 @@ void Slider::onMouseUp(EventHandler::MouseButton button, int x, int y)
 /**
  *
  */
-void Slider::onMouseMotion(int x, int y, int dX, int dY)
+void Slider::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!enabled() || !visible() || !hasFocus()) { return; }
 

--- a/src/UI/Core/TextArea.h
+++ b/src/UI/Core/TextArea.h
@@ -14,7 +14,7 @@ public:
 	TextArea() = default;
 	virtual ~TextArea() = default;
 
-	void textColor(int r, int g, int b, int a = 255) { mTextColor(r, g, b, a); }
+	void textColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) { mTextColor(r, g, b, a); }
 
 	void font(const std::string&, size_t);
 

--- a/src/UI/Core/TextField.cpp
+++ b/src/UI/Core/TextField.cpp
@@ -139,13 +139,13 @@ void TextField::onTextInput(const std::string& _s)
 
 	if (mMaxCharacters > 0 && text().length() == mMaxCharacters) { return; }
 
-	int prvLen = text().length();
+	std::size_t prvLen = text().length();
 
 	if (mNumbersOnly && !std::isdigit(_s[0], LOC)) { return; }
 
 	_text() = _text().insert(mCursorPosition, _s);
 
-	if (text().length() - prvLen != 0)
+	if (text().length() - prvLen != 0u)
 	{
 		onTextChanged();
 		mCursorPosition++;
@@ -174,7 +174,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /
 			break;
 
 		case EventHandler::KeyCode::KEY_END:
-			mCursorPosition = text().length();
+			mCursorPosition = static_cast<int>(text().length());
 			break;
 
 		case EventHandler::KeyCode::KEY_DELETE:
@@ -234,7 +234,7 @@ void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 	// set the position to the end and move on.
 	if(TXT_FONT->width(text()) < relativePosition)
 	{
-		mCursorPosition = text().size();
+		mCursorPosition = static_cast<int>(text().size());
 		return;
 	}
 

--- a/src/UI/Core/TextField.cpp
+++ b/src/UI/Core/TextField.cpp
@@ -153,7 +153,7 @@ void TextField::onTextInput(const std::string& _s)
 }
 
 
-void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!hasFocus() || !editable() || !visible()) { return; }
 
@@ -222,7 +222,7 @@ void TextField::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier m
 /**
  * Mouse down even handler.
  */
-void TextField::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void TextField::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	hasFocus(isPointInRect(Point_2d(x, y), rect())); // This is a very useful check, should probably include this in all controls.
 

--- a/src/UI/Core/UIContainer.cpp
+++ b/src/UI/Core/UIContainer.cpp
@@ -113,7 +113,7 @@ void UIContainer::positionChanged(float dX, float dY)
 /**
  * 
  */
-void UIContainer::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void UIContainer::onMouseDown(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	if (!visible()) { return; }
 

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -62,13 +62,13 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void Window::onMouseUp(EventHandler::MouseButton button, int x, int y)
+void Window::onMouseUp(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
 {
 	mMouseDrag = false;
 }
 
 
-void Window::onMouseMotion(int x, int y, int dX, int dY)
+void Window::onMouseMotion(int /*x*/, int /*y*/, int dX, int dY)
 {
 	if (!visible() || !hasFocus()) { return; }
 

--- a/src/UI/FactoryListBox.cpp
+++ b/src/UI/FactoryListBox.cpp
@@ -136,7 +136,7 @@ void FactoryListBox::currentSelection(Factory* f)
 		FactoryListBoxItem* item = static_cast<FactoryListBoxItem*>(mItems[i]);
 		if (item->factory == f)
 		{
-			setSelection(i);
+			setSelection(static_cast<int>(i));
 			return;
 		}
 	}

--- a/src/UI/FileIo.cpp
+++ b/src/UI/FileIo.cpp
@@ -68,7 +68,7 @@ void FileIo::init()
 /**
  * Event handler for mouse double click.
  */
-void FileIo::onDoubleClick(EventHandler::MouseButton button, int x, int y)
+void FileIo::onDoubleClick(EventHandler::MouseButton /*button*/, int x, int y)
 {
 	if (!visible()) { return; }	// ignore key presses when hidden.
 
@@ -86,7 +86,7 @@ void FileIo::onDoubleClick(EventHandler::MouseButton button, int x, int y)
 /**
  * Event handler for Key Down.
  */
-void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void FileIo::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	if (!visible()) { return; }	// ignore key presses when hidden.
 

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -417,8 +417,8 @@ void IconGrid::update()
 
 	for (size_t i = 0; i < mIconItemList.size(); ++i)
 	{
-		int x_pos = i % mGridSize.x();
-		int y_pos = i / mGridSize.x(); //-V537
+		int x_pos = static_cast<int>(i) % mGridSize.x();
+		int y_pos = static_cast<int>(i) / mGridSize.x(); //-V537
 
 		float x = static_cast<float>((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos));
 		float y = static_cast<float>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));
@@ -431,8 +431,8 @@ void IconGrid::update()
 
 	if (mCurrentSelection != constants::NO_SELECTION)
 	{
-		int x_pos = (mCurrentSelection % mGridSize.x());
-		int y_pos = (mCurrentSelection / mGridSize.x()); //-V537
+		int x_pos = (static_cast<int>(mCurrentSelection) % mGridSize.x());
+		int y_pos = (static_cast<int>(mCurrentSelection) / mGridSize.x()); //-V537
 		r.drawBox((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos),
 			(rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos),
 			static_cast<float>(mIconSize),
@@ -441,8 +441,8 @@ void IconGrid::update()
 
 	if (mHighlightIndex != constants::NO_SELECTION)
 	{
-		int x_pos = (mHighlightIndex % mGridSize.x());
-		int y_pos = (mHighlightIndex / mGridSize.x()); //-V537
+		int x_pos = (static_cast<int>(mHighlightIndex) % mGridSize.x());
+		int y_pos = (static_cast<int>(mHighlightIndex) / mGridSize.x()); //-V537
 
 		int x = static_cast<int>((rect().x() + mIconMargin) + (x_pos * mIconSize) + (mIconMargin * x_pos));
 		int y = static_cast<int>((rect().y() + mIconMargin) + (y_pos * mIconSize) + (mIconMargin * y_pos));

--- a/src/UI/IconGrid.cpp
+++ b/src/UI/IconGrid.cpp
@@ -129,7 +129,7 @@ void IconGrid::onMouseDown(EventHandler::MouseButton button, int x, int y)
 /**
  * MouseMotion event handler.
  */
-void IconGrid::onMouseMotion(int x, int y, int dX, int dY)
+void IconGrid::onMouseMotion(int x, int y, int /*dX*/, int /*dY*/)
 {
 	if (!visible() || !hasFocus()) { return; }
 

--- a/src/UI/IconGrid.h
+++ b/src/UI/IconGrid.h
@@ -53,7 +53,7 @@ public:
 
 	const std::string& itemName(int _sel) const { return mIconItemList[_sel].name; }
 
-	int selectionIndex() const { return mCurrentSelection; }
+	int selectionIndex() const { return static_cast<int>(mCurrentSelection); }
 
 	bool empty() const { return mIconItemList.empty(); }
 

--- a/src/UI/Reports/FactoryReport.cpp
+++ b/src/UI/Reports/FactoryReport.cpp
@@ -321,7 +321,7 @@ void FactoryReport::checkFactoryActionControls()
 /**
  * 
  */
-void FactoryReport::resized(Control* c)
+void FactoryReport::resized(Control* /*c*/)
 {
 	FACTORY_LISTBOX.x(positionX() + 10);
 	FACTORY_LISTBOX.y(cboFilterByProduct.positionY() + cboFilterByProduct.height() + 10);

--- a/src/UI/StructureListBox.cpp
+++ b/src/UI/StructureListBox.cpp
@@ -124,7 +124,7 @@ void StructureListBox::currentSelection(Structure* structure)
 		StructureListBoxItem* item = static_cast<StructureListBoxItem*>(mItems[i]);
 		if (item->structure == structure)
 		{
-			setSelection(i);
+			setSelection(static_cast<int>(i));
 			return;
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,9 +49,8 @@ void validateVideoResolution()
 }
 
 
-int main(int argc, char *argv[])
+int main(int /*argc*/, char *argv[])
 {
-	(void)argc; //UNUSED
 	//Crude way of redirecting stream buffer when building in release (no console)
 	#ifdef NDEBUG
 	std::streambuf *backup;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ void validateVideoResolution()
 
 int main(int argc, char *argv[])
 {
+	(void)argc; //UNUSED
 	//Crude way of redirecting stream buffer when building in release (no console)
 	#ifdef NDEBUG
 	std::streambuf *backup;


### PR DESCRIPTION
This fixes over 400 warnings in both Debug and Release builds.

It deliberately skips warnings emitted from third-party code such as Micropather.

Keeping on top of warnings as they occur will reduce massive chagesets like this in teh future.