### PR TITLE
Makes WINDOW_TITLE_HEIGHT visible to derived classes

### DIFF
--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -57,7 +57,7 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	UIContainer::onMouseDown(button, x, y);
 
-	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), Window::getWindowTitleBarHeight()));
+	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), sWindowTitleBarHeight));
 }
 
 
@@ -97,7 +97,7 @@ void Window::update()
 	Renderer& r = Utility<Renderer>::get();
 
 	r.drawImage(mTitle[0], rect().x(), rect().y());
-	r.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, Window::getWindowTitleBarHeight());
+	r.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, sWindowTitleBarHeight);
 	r.drawImage(mTitle[2], rect().x() + rect().width() - 4, rect().y());
 
 	r.drawImageRect(rect().x(), rect().y() + 20, rect().width(), rect().height() - 20, mBody);

--- a/src/UI/Core/Window.cpp
+++ b/src/UI/Core/Window.cpp
@@ -12,7 +12,6 @@
 
 using namespace NAS2D;
 
-const float WINDOW_TITLE_BAR_HEIGHT = 20.0f;
 static Font* WINDOW_TITLE_FONT;
 
 Window::Window()
@@ -58,7 +57,7 @@ void Window::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	UIContainer::onMouseDown(button, x, y);
 
-	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), WINDOW_TITLE_BAR_HEIGHT));
+	mMouseDrag = (button == EventHandler::MouseButton::BUTTON_LEFT && pointInRect_f(x, y, rect().x(), rect().y(), rect().width(), Window::getWindowTitleBarHeight()));
 }
 
 
@@ -77,7 +76,6 @@ void Window::onMouseMotion(int x, int y, int dX, int dY)
 		position(positionX() + dX, positionY() + dY);
 	}
 }
-
 
 void Window::anchored(bool _a)
 {
@@ -99,7 +97,7 @@ void Window::update()
 	Renderer& r = Utility<Renderer>::get();
 
 	r.drawImage(mTitle[0], rect().x(), rect().y());
-	r.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, WINDOW_TITLE_BAR_HEIGHT);
+	r.drawImageRepeated(mTitle[1], rect().x() + 4, rect().y(), rect().width() - 8, Window::getWindowTitleBarHeight());
 	r.drawImage(mTitle[2], rect().x() + rect().width() - 4, rect().y());
 
 	r.drawImageRect(rect().x(), rect().y() + 20, rect().width(), rect().height() - 20, mBody);

--- a/src/UI/Core/Window.h
+++ b/src/UI/Core/Window.h
@@ -19,7 +19,9 @@ protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMotion(int x, int y, int dX, int dY);
-	static inline constexpr float getWindowTitleBarHeight() { return sWindowTitleBarHeight; };
+
+	static inline constexpr float sWindowTitleBarHeight = 20.0f;
+
 private:
 	void _init();
 
@@ -29,5 +31,4 @@ private:
 
 	NAS2D::ImageList	mTitle;
 	NAS2D::ImageList	mBody;
-	static inline constexpr float sWindowTitleBarHeight = 20.0f;
 };

--- a/src/UI/Core/Window.h
+++ b/src/UI/Core/Window.h
@@ -19,7 +19,7 @@ protected:
 	void onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y);
 	void onMouseMotion(int x, int y, int dX, int dY);
-
+	static inline constexpr float getWindowTitleBarHeight() { return sWindowTitleBarHeight; };
 private:
 	void _init();
 
@@ -29,4 +29,5 @@ private:
 
 	NAS2D::ImageList	mTitle;
 	NAS2D::ImageList	mBody;
+	static inline constexpr float sWindowTitleBarHeight = 20.0f;
 };

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -45,7 +45,7 @@ void MainMenuOptions::init()
 
     const auto border_left_width = 5;
     const auto border_right_width = 5;
-    constexpr auto border_top_height = Window::getWindowTitleBarHeight() + 5;
+    constexpr auto border_top_height = sWindowTitleBarHeight + 5;
     const auto border_bottom_height = 5;
     const auto element_spacing = 5;
     const auto left_edge = positionX() + border_left_width;

--- a/src/UI/MainMenuOptions.cpp
+++ b/src/UI/MainMenuOptions.cpp
@@ -45,7 +45,7 @@ void MainMenuOptions::init()
 
     const auto border_left_width = 5;
     const auto border_right_width = 5;
-    const auto border_top_height = 25; //WINDOW_TITLE_HEIGHT + 5
+    constexpr auto border_top_height = Window::getWindowTitleBarHeight() + 5;
     const auto border_bottom_height = 5;
     const auto element_spacing = 5;
     const auto left_edge = positionX() + border_left_width;


### PR DESCRIPTION
This is a branch off of #153 only the last two commits are new.

Previously WINDOW_TITLE_HEIGHT was internal to `Window.cpp` and unavailable to derived classes for GUI element positioning. This PR makes the variable a compile-time constant and visible to derived classes through a getter.