### PR TITLE
Debug code left in MapViewStateTurn.cpp

### DIFF
--- a/src/States/MapViewStateTurn.cpp
+++ b/src/States/MapViewStateTurn.cpp
@@ -318,11 +318,6 @@ void MapViewState::nextTurn()
 	mMineOperationsWindow.updateCounts();
 	mStructureInspector.check();
 
-
-	float totalCost = 0;
-	int result = pather->Solve(mTileMap->getTile(299, 149), mTileMap->getTile(10, 10), &path, &totalCost);
-
-
 	// Check for Game Over conditions
 	if (mPopulation.size() < 1 && mLandersColonist == 0)
 	{


### PR DESCRIPTION
Part of splitting up #155 into smaller commits.

Fixes only removing the debug code in `MapViewStateTurn.cpp`