### PR TITLE
Remove `std::floor` (Fix Clang error)

### DIFF
--- a/src/States/MainReportsUiState.cpp
+++ b/src/States/MainReportsUiState.cpp
@@ -206,7 +206,7 @@ void MainReportsUiState::initialize()
 	Panels[PANEL_SPACEPORT].Name = "Space Ports";
 
 	Renderer& r = Utility<Renderer>::get();
-	setPanelRects(static_cast<int>(std::floor(r.width())));
+	setPanelRects(static_cast<int>(r.width()));
 
 	// INIT UI REPORT PANELS
 	ReportInterface* factory_report = new FactoryReport();


### PR DESCRIPTION
It's unclear why this was added, or if it was intentional. Having it there breaks the build for Clang since there was no `<cmath>` include.
