### PR TITLE
Makefile remove debug info

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,9 +9,9 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)include/
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
-CXXFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
-LDFLAGS := -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
-LDLIBS := -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
+CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+LDFLAGS := $(LDFLAGS.EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
+LDLIBS := $(LDLIBS.EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
 CPPFLAGS := $(CPPFLAGS.EXTRA)
-CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS.EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
 

--- a/makefile
+++ b/makefile
@@ -9,13 +9,14 @@ NAS2DINCLUDEDIR := $(NAS2DDIR)include/
 NAS2DLIBDIR := $(NAS2DDIR)lib/
 NAS2DLIB := $(NAS2DLIBDIR)libnas2d.a
 
+CPPFLAGS := $(CPPFLAGS.EXTRA)
 CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -g -Wall -Wno-unknown-pragmas -I$(NAS2DINCLUDEDIR) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA) -L$(NAS2DLIBDIR) $(shell sdl2-config --libs)
 LDLIBS := $(LDLIBS.EXTRA) -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL -lGLEW
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)$*.Td
 
-COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
+COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 POSTCOMPILE = @mv -f $(OBJDIR)$*.Td $(OBJDIR)$*.d && touch $@
 
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')


### PR DESCRIPTION
Removes debug info as a default build flag.

Adds ability to specify arbitrary additional flags when building through variable parameters to `make`. This can be used to generate debug information, set optimization level, or enable instrumentation for code coverage.

Example to compile with debug info:
```
make CXXFLAGS.EXTRA="-g"
```

----

Makefile only change.
