### PR TITLE
Update NAS2D for removal of `dataPath` parameter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,8 @@ int main(int /*argc*/, char *argv[])
 
 	try
 	{
-		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks", "data");
+		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OutpostHD", "LairWorks");
+		f.mount(f.basePath() + "data");
 
 		if (!f.exists(constants::SAVE_GAME_PATH))
 		{


### PR DESCRIPTION
This is the corresponding update to the breaking change in NAS2D that removes the `Filesystem`'s `dataPath` parameter.

Reference: https://github.com/lairworks/nas2d-core/pull/442
